### PR TITLE
fix(security): harden contact API, patch high-severity deps, unblock CI

### DIFF
--- a/app/[locale]/layout.tsx
+++ b/app/[locale]/layout.tsx
@@ -12,6 +12,7 @@ import { BackToTopButton } from '@/components/ui/BackToTopButton';
 import { LocaleProvider } from '@/components/providers/LocaleProvider';
 import { MotionProvider } from '@/components/providers/MotionProvider';
 import { getMessages, isValidLocale, locales, type Locale } from '@/lib/i18n';
+import { toJsonLd } from '@/lib/json-ld';
 
 type Props = { children: React.ReactNode; params: Promise<{ locale: string }> };
 
@@ -76,7 +77,7 @@ export default async function LocaleLayout({ children, params }: Props) {
       <MotionProvider>
         <script
           type="application/ld+json"
-          dangerouslySetInnerHTML={{ __html: JSON.stringify(personJsonLd) }}
+          dangerouslySetInnerHTML={{ __html: toJsonLd(personJsonLd) }}
         />
         <a
           href="#main-content"

--- a/app/api/contact/route.test.ts
+++ b/app/api/contact/route.test.ts
@@ -202,14 +202,40 @@ describe('POST /api/contact', () => {
       expect(res.status).toBe(200);
     });
 
-    it('allows Vercel preview deploys matching the project', async () => {
-      const res = await POST(
-        makeRequest(validBody, {
-          Origin: 'https://zachlamb-git-pr-123.vercel.app',
-          'x-forwarded-for': nextTestIp(),
-        }),
-      );
-      expect(res.status).toBe(200);
+    it('allows the Vercel preview deploy named by VERCEL_BRANCH_URL', async () => {
+      vi.stubEnv('VERCEL_BRANCH_URL', 'zachlamb-git-pr-123.vercel.app');
+      try {
+        const res = await POST(
+          makeRequest(validBody, {
+            Origin: 'https://zachlamb-git-pr-123.vercel.app',
+            'x-forwarded-for': nextTestIp(),
+          }),
+        );
+        expect(res.status).toBe(200);
+      } finally {
+        vi.unstubAllEnvs();
+        vi.stubEnv('RESEND_API_KEY', 'test_key');
+      }
+    });
+
+    // Regression: the origin check used to accept any *.vercel.app host whose
+    // name merely contained "zachlamb". Vercel project names are globally
+    // claimable, so a third party could deploy "zachlamb-evil" and satisfy the
+    // CSRF gate. Only exact matches against Vercel's own env vars count now.
+    it('rejects a third-party vercel.app host that merely contains the project name', async () => {
+      vi.stubEnv('VERCEL_BRANCH_URL', 'zachlamb-git-pr-123.vercel.app');
+      try {
+        const res = await POST(
+          makeRequest(validBody, {
+            Origin: 'https://zachlamb-evil.vercel.app',
+            'x-forwarded-for': nextTestIp(),
+          }),
+        );
+        expect(res.status).toBe(403);
+      } finally {
+        vi.unstubAllEnvs();
+        vi.stubEnv('RESEND_API_KEY', 'test_key');
+      }
     });
 
     it('rejects a non-https Origin that spoofs the vercel.app suffix', async () => {
@@ -220,6 +246,85 @@ describe('POST /api/contact', () => {
         }),
       );
       expect(res.status).toBe(403);
+    });
+
+    it('rejects a plaintext localhost Origin in production', async () => {
+      vi.stubEnv('NODE_ENV', 'production');
+      try {
+        const res = await POST(
+          makeRequest(validBody, {
+            Origin: 'http://localhost:3000',
+            'x-forwarded-for': nextTestIp(),
+          }),
+        );
+        expect(res.status).toBe(403);
+      } finally {
+        vi.unstubAllEnvs();
+        vi.stubEnv('RESEND_API_KEY', 'test_key');
+      }
+    });
+  });
+
+  describe('Body type validation', () => {
+    const ip = () => ({ 'x-forwarded-for': nextTestIp() });
+
+    it.each([
+      ['number', 42],
+      ['object', { toString: 'x' }],
+      ['array', ['Frodo']],
+      ['boolean', true],
+      ['null', null],
+    ])('returns 400 (not 500) when name is a %s', async (_label, value) => {
+      const res = await POST(
+        makeRequest({ name: value, email: 'frodo@shire.me', message: 'Hello!' }, ip()),
+      );
+      expect(res.status).toBe(400);
+    });
+
+    it('returns 400 when email is a non-string that would coerce past the regex', async () => {
+      const res = await POST(
+        makeRequest({ name: 'Frodo', email: ['frodo@shire.me'], message: 'Hello!' }, ip()),
+      );
+      expect(res.status).toBe(400);
+      expect(sendMock).not.toHaveBeenCalled();
+    });
+
+    it('returns 400 when the JSON body is an array', async () => {
+      const req = new Request('http://localhost/api/contact', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Origin: 'http://localhost:3000',
+          ...ip(),
+        } as HeadersInit,
+        body: JSON.stringify([{ name: 'Frodo' }]),
+      });
+      expect((await POST(req)).status).toBe(400);
+    });
+
+    it('returns 400 when the JSON body is a bare string', async () => {
+      const req = new Request('http://localhost/api/contact', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Origin: 'http://localhost:3000',
+          ...ip(),
+        } as HeadersInit,
+        body: JSON.stringify('nope'),
+      });
+      expect((await POST(req)).status).toBe(400);
+    });
+
+    it('trims surrounding whitespace rather than rejecting the message', async () => {
+      const res = await POST(
+        makeRequest(
+          { name: 'Frodo', email: 'frodo@shire.me', message: `${' '.repeat(10)}hello` },
+          ip(),
+        ),
+      );
+      expect(res.status).toBe(200);
+      const text = sendMock.mock.calls.at(-1)?.[0]?.text as string;
+      expect(text).toContain('hello');
     });
   });
 
@@ -262,7 +367,9 @@ describe('POST /api/contact', () => {
         const res = await POST(
           makeRequest(
             { name: 'Frodo', email: 'frodo@shire.me', message: 'Hello!' },
-            { 'x-forwarded-for': nextTestIp() },
+            // Must be a production-valid Origin: localhost is only trusted
+            // outside production now.
+            { Origin: 'https://zachlamb.io', 'x-forwarded-for': nextTestIp() },
           ),
         );
         expect(res.status).toBe(500);

--- a/app/api/contact/route.ts
+++ b/app/api/contact/route.ts
@@ -20,25 +20,39 @@ const MAX_NAME_LENGTH = 200;
 const MAX_EMAIL_LENGTH = 320;
 const MAX_MESSAGE_LENGTH = 5000;
 
-const ALLOWED_ORIGINS = new Set<string>([
-  'https://zachlamb.io',
-  'https://www.zachlamb.io',
-  'http://localhost:3000',
-  'http://localhost',
-]);
+const ALLOWED_ORIGINS = new Set<string>(['https://zachlamb.io', 'https://www.zachlamb.io']);
+
+// Only trusted outside production, so a prod deploy never accepts a plaintext
+// localhost Origin as a same-site request.
+const DEV_ALLOWED_ORIGINS = new Set<string>(['http://localhost:3000', 'http://localhost']);
+
+/**
+ * Origins for the current Vercel deployment, derived from the server-only env
+ * vars Vercel injects at runtime (no NEXT_PUBLIC_ prefix, so they never reach
+ * the client bundle).
+ *
+ * This replaces a substring heuristic (`hostname.endsWith('.vercel.app') &&
+ * hostname.includes('zachlamb')`) that any third party could satisfy: Vercel
+ * project names are globally claimable, so deploying a project named
+ * `zachlamb-anything` yields `zachlamb-anything.vercel.app` and passed the old
+ * check — defeating the CSRF origin gate. Exact matching against the values
+ * Vercel gives us keeps preview deploys working with no wildcard to abuse.
+ */
+function getVercelOrigins(): string[] {
+  return [
+    process.env.VERCEL_PROJECT_PRODUCTION_URL,
+    process.env.VERCEL_BRANCH_URL,
+    process.env.VERCEL_URL,
+  ]
+    .filter((host): host is string => typeof host === 'string' && host.trim() !== '')
+    .map((host) => `https://${host.trim()}`);
+}
 
 function isOriginAllowed(origin: string | null): boolean {
   if (!origin) return false;
   if (ALLOWED_ORIGINS.has(origin)) return true;
-  try {
-    const { hostname, protocol } = new URL(origin);
-    if (protocol !== 'https:') return false;
-    // Vercel preview deploys for this project
-    if (hostname.endsWith('.vercel.app') && hostname.includes('zachlamb')) return true;
-  } catch {
-    return false;
-  }
-  return false;
+  if (process.env.NODE_ENV !== 'production' && DEV_ALLOWED_ORIGINS.has(origin)) return true;
+  return getVercelOrigins().includes(origin);
 }
 
 function getClientId(request: Request): string {
@@ -62,7 +76,7 @@ export async function POST(request: Request) {
     return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
   }
 
-  let body: { name?: string; email?: string; message?: string };
+  let body: unknown;
 
   try {
     body = await request.json();
@@ -70,9 +84,29 @@ export async function POST(request: Request) {
     return NextResponse.json({ error: 'Invalid JSON' }, { status: 400 });
   }
 
-  const { name, email, message } = body;
+  // Parse, don't validate: everything past this point is a known-good string.
+  // The body is attacker-controlled JSON, so each field must be type-checked
+  // before any string method touches it — `name.trim()` on a number, array, or
+  // object throws a TypeError that would escape the handler as an opaque 500.
+  if (typeof body !== 'object' || body === null || Array.isArray(body)) {
+    return NextResponse.json({ error: 'Invalid JSON' }, { status: 400 });
+  }
 
-  if (!name?.trim() || !email?.trim() || !message?.trim()) {
+  const { name: rawName, email: rawEmail, message: rawMessage } = body as Record<string, unknown>;
+
+  if (
+    typeof rawName !== 'string' ||
+    typeof rawEmail !== 'string' ||
+    typeof rawMessage !== 'string'
+  ) {
+    return NextResponse.json({ error: 'Name, email, and message are required' }, { status: 400 });
+  }
+
+  const name = rawName.trim();
+  const email = rawEmail.trim();
+  const message = rawMessage.trim();
+
+  if (!name || !email || !message) {
     return NextResponse.json({ error: 'Name, email, and message are required' }, { status: 400 });
   }
 

--- a/app/globals.css
+++ b/app/globals.css
@@ -114,43 +114,84 @@ html:lang(it) nav [data-nav-link] {
 }
 
 @keyframes contour-drift-a {
-  0%, 100% { transform: translate(0, 0); }
-  50% { transform: translate(8px, -5px); }
+  0%,
+  100% {
+    transform: translate(0, 0);
+  }
+  50% {
+    transform: translate(8px, -5px);
+  }
 }
 
 @keyframes contour-drift-b {
-  0%, 100% { transform: translate(0, 0); }
-  50% { transform: translate(-6px, 8px); }
+  0%,
+  100% {
+    transform: translate(0, 0);
+  }
+  50% {
+    transform: translate(-6px, 8px);
+  }
 }
 
 @keyframes contour-drift-c {
-  0%, 100% { transform: translate(0, 0); }
-  50% { transform: translate(10px, 6px); }
+  0%,
+  100% {
+    transform: translate(0, 0);
+  }
+  50% {
+    transform: translate(10px, 6px);
+  }
 }
 
 @keyframes mountain-sway-far {
-  0%, 100% { transform: translateY(0); }
-  50% { transform: translateY(-1px); }
+  0%,
+  100% {
+    transform: translateY(0);
+  }
+  50% {
+    transform: translateY(-1px);
+  }
 }
 
 @keyframes mountain-sway-near {
-  0%, 100% { transform: translateY(0); }
-  50% { transform: translateY(-2px); }
+  0%,
+  100% {
+    transform: translateY(0);
+  }
+  50% {
+    transform: translateY(-2px);
+  }
 }
 
 @keyframes mountain-sway-tree {
-  0%, 100% { transform: translateY(0); }
-  50% { transform: translateY(-1.5px); }
+  0%,
+  100% {
+    transform: translateY(0);
+  }
+  50% {
+    transform: translateY(-1.5px);
+  }
 }
 
 @keyframes star-drift {
-  0%, 100% { transform: translate(0, 0); opacity: var(--star-opacity); }
-  50% { transform: translate(var(--star-dx), var(--star-dy)); opacity: calc(var(--star-opacity) * 1.5); }
+  0%,
+  100% {
+    transform: translate(0, 0);
+    opacity: var(--star-opacity);
+  }
+  50% {
+    transform: translate(var(--star-dx), var(--star-dy));
+    opacity: calc(var(--star-opacity) * 1.5);
+  }
 }
 
 @keyframes endorsement-marquee {
-  from { transform: translateX(0); }
-  to { transform: translateX(-50%); }
+  from {
+    transform: translateX(0);
+  }
+  to {
+    transform: translateX(-50%);
+  }
 }
 
 @keyframes topo-pulse {

--- a/components/layout/Navbar.tsx
+++ b/components/layout/Navbar.tsx
@@ -112,130 +112,130 @@ export function Navbar() {
 
   return (
     <>
-    <header className="bg-parchment/90 border-bark/10 sticky top-0 z-50 border-b pt-[env(safe-area-inset-top)] backdrop-blur-md">
-      <nav
-        aria-label="Main navigation"
-        className="mx-auto flex h-16 max-w-5xl items-center justify-between px-6"
-      >
-        <a
-          href={`${basePath}#hero`}
-          className="group text-forest hover:text-forest/80 flex items-center gap-2 font-serif text-xl font-semibold transition-colors"
-          aria-label={messages.nav.backToTop}
+      <header className="bg-parchment/90 border-bark/10 sticky top-0 z-50 border-b pt-[env(safe-area-inset-top)] backdrop-blur-md">
+        <nav
+          aria-label="Main navigation"
+          className="mx-auto flex h-16 max-w-5xl items-center justify-between px-6"
         >
-          <Compass className="text-gold h-5 w-5 transition-transform duration-500 group-hover:rotate-45" />
-          {messages.site.name}
-        </a>
+          <a
+            href={`${basePath}#hero`}
+            className="group text-forest hover:text-forest/80 flex items-center gap-2 font-serif text-xl font-semibold transition-colors"
+            aria-label={messages.nav.backToTop}
+          >
+            <Compass className="text-gold h-5 w-5 transition-transform duration-500 group-hover:rotate-45" />
+            {messages.site.name}
+          </a>
 
-        {/* Desktop links + language dropdown */}
-        <ul className="hidden flex-wrap items-center gap-6 md:flex">
-          {navLinks.map((link) => {
-            const isActive = activeSection === link.id;
-            return (
-              <li key={link.href} className="shrink-0">
-                <a
-                  href={link.href}
-                  data-nav-link
-                  className={cn(
-                    'relative text-sm whitespace-nowrap transition-colors after:absolute after:bottom-[-2px] after:left-0 after:h-px after:transition-all after:duration-300 hover:after:w-full',
-                    isActive
-                      ? 'text-gold after:bg-gold font-medium after:w-full'
-                      : 'text-bark after:bg-gold hover:text-gold after:w-0 hover:after:w-full',
-                  )}
-                  aria-current={isActive ? 'location' : undefined}
-                >
-                  {link.label}
-                </a>
-              </li>
-            );
-          })}
-          <li className="shrink-0">
-            <LanguageDropdown id="language-select-desktop" />
-          </li>
-        </ul>
+          {/* Desktop links + language dropdown */}
+          <ul className="hidden flex-wrap items-center gap-6 md:flex">
+            {navLinks.map((link) => {
+              const isActive = activeSection === link.id;
+              return (
+                <li key={link.href} className="shrink-0">
+                  <a
+                    href={link.href}
+                    data-nav-link
+                    className={cn(
+                      'relative text-sm whitespace-nowrap transition-colors after:absolute after:bottom-[-2px] after:left-0 after:h-px after:transition-all after:duration-300 hover:after:w-full',
+                      isActive
+                        ? 'text-gold after:bg-gold font-medium after:w-full'
+                        : 'text-bark after:bg-gold hover:text-gold after:w-0 hover:after:w-full',
+                    )}
+                    aria-current={isActive ? 'location' : undefined}
+                  >
+                    {link.label}
+                  </a>
+                </li>
+              );
+            })}
+            <li className="shrink-0">
+              <LanguageDropdown id="language-select-desktop" />
+            </li>
+          </ul>
 
-        {/* Mobile toggle – 44px min touch target */}
-        <button
-          ref={toggleButtonRef}
-          type="button"
-          className="text-bark flex min-h-11 min-w-11 touch-manipulation items-center justify-center rounded-md md:hidden"
-          onClick={() => setMobileOpen((prev) => !prev)}
-          aria-label={mobileOpen ? messages.nav.closeMenu : messages.nav.openMenu}
-          aria-expanded={mobileOpen}
-          aria-controls="mobile-nav"
-        >
-          <Compass
-            className={cn(
-              'h-6 w-6 transition-transform duration-500',
-              mobileOpen ? 'rotate-[360deg] text-gold' : '',
-            )}
-          />
-        </button>
-      </nav>
-
-    </header>
+          {/* Mobile toggle – 44px min touch target */}
+          <button
+            ref={toggleButtonRef}
+            type="button"
+            className="text-bark flex min-h-11 min-w-11 touch-manipulation items-center justify-center rounded-md md:hidden"
+            onClick={() => setMobileOpen((prev) => !prev)}
+            aria-label={mobileOpen ? messages.nav.closeMenu : messages.nav.openMenu}
+            aria-expanded={mobileOpen}
+            aria-controls="mobile-nav"
+          >
+            <Compass
+              className={cn(
+                'h-6 w-6 transition-transform duration-500',
+                mobileOpen ? 'text-gold rotate-[360deg]' : '',
+              )}
+            />
+          </button>
+        </nav>
+      </header>
 
       {/* Mobile fullscreen overlay — portaled to <body> so backdrop-blur on <header> doesn't create a containing block that traps the fixed positioning */}
-      {mounted && createPortal(
-        <div
-          id="mobile-nav"
-          role={mobileOpen ? 'dialog' : undefined}
-          aria-modal={mobileOpen ? 'true' : undefined}
-          aria-label={mobileOpen ? messages.nav.openMenu : undefined}
-          className={cn(
-            'fixed inset-0 z-[60] flex flex-col items-center justify-center bg-forest transition-opacity duration-300 md:hidden',
-            mobileOpen ? 'pointer-events-auto opacity-100' : 'pointer-events-none opacity-0',
-          )}
-          style={{
-            backgroundImage: `url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='40' height='40'%3E%3Cpath d='M0 20h40M20 0v40' fill='none' stroke='%23f5f0e8' stroke-width='0.15' opacity='0.04'/%3E%3C/svg%3E")`,
-          }}
-          onClick={(e) => {
-            if (e.target === e.currentTarget) setMobileOpen(false);
-          }}
-        >
-          {/* Close button — same position as toggle */}
-          <button
-            type="button"
-            className="text-parchment hover:text-gold absolute top-[env(safe-area-inset-top)] right-0 flex min-h-11 min-w-11 touch-manipulation items-center justify-center p-6"
-            onClick={() => setMobileOpen(false)}
-            aria-label={messages.nav.closeMenu}
+      {mounted &&
+        createPortal(
+          <div
+            id="mobile-nav"
+            role={mobileOpen ? 'dialog' : undefined}
+            aria-modal={mobileOpen ? 'true' : undefined}
+            aria-label={mobileOpen ? messages.nav.openMenu : undefined}
+            className={cn(
+              'bg-forest fixed inset-0 z-[60] flex flex-col items-center justify-center transition-opacity duration-300 md:hidden',
+              mobileOpen ? 'pointer-events-auto opacity-100' : 'pointer-events-none opacity-0',
+            )}
+            style={{
+              backgroundImage: `url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='40' height='40'%3E%3Cpath d='M0 20h40M20 0v40' fill='none' stroke='%23f5f0e8' stroke-width='0.15' opacity='0.04'/%3E%3C/svg%3E")`,
+            }}
+            onClick={(e) => {
+              if (e.target === e.currentTarget) setMobileOpen(false);
+            }}
           >
-            <X className="h-6 w-6" />
-          </button>
-          <ul ref={menuRef} className="flex flex-col items-center gap-6">
-            {navLinks.map((link, i) => (
+            {/* Close button — same position as toggle */}
+            <button
+              type="button"
+              className="text-parchment hover:text-gold absolute top-[env(safe-area-inset-top)] right-0 flex min-h-11 min-w-11 touch-manipulation items-center justify-center p-6"
+              onClick={() => setMobileOpen(false)}
+              aria-label={messages.nav.closeMenu}
+            >
+              <X className="h-6 w-6" />
+            </button>
+            <ul ref={menuRef} className="flex flex-col items-center gap-6">
+              {navLinks.map((link, i) => (
+                <li
+                  key={link.href}
+                  style={{
+                    transitionDelay: mobileOpen ? `${i * 50}ms` : '0ms',
+                    opacity: mobileOpen ? 1 : 0,
+                    transform: mobileOpen ? 'translateY(0)' : 'translateY(16px)',
+                    transition: 'opacity 300ms ease, transform 300ms ease',
+                  }}
+                >
+                  <a
+                    href={link.href}
+                    className="text-parchment hover:text-gold focus-visible:ring-gold flex min-h-11 touch-manipulation items-center rounded-md px-4 py-2 font-serif text-xl transition-colors focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none"
+                    onClick={() => setMobileOpen(false)}
+                  >
+                    {link.label}
+                  </a>
+                </li>
+              ))}
               <li
-                key={link.href}
+                className="border-parchment/10 mt-4 border-t pt-4"
                 style={{
-                  transitionDelay: mobileOpen ? `${i * 50}ms` : '0ms',
+                  transitionDelay: mobileOpen ? `${navLinks.length * 50}ms` : '0ms',
                   opacity: mobileOpen ? 1 : 0,
                   transform: mobileOpen ? 'translateY(0)' : 'translateY(16px)',
                   transition: 'opacity 300ms ease, transform 300ms ease',
                 }}
               >
-                <a
-                  href={link.href}
-                  className="text-parchment hover:text-gold focus-visible:ring-gold flex min-h-11 touch-manipulation items-center rounded-md px-4 py-2 font-serif text-xl transition-colors focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none"
-                  onClick={() => setMobileOpen(false)}
-                >
-                  {link.label}
-                </a>
+                <LanguageDropdown compact id="language-select-mobile" />
               </li>
-            ))}
-            <li
-              className="border-parchment/10 mt-4 border-t pt-4"
-              style={{
-                transitionDelay: mobileOpen ? `${navLinks.length * 50}ms` : '0ms',
-                opacity: mobileOpen ? 1 : 0,
-                transform: mobileOpen ? 'translateY(0)' : 'translateY(16px)',
-                transition: 'opacity 300ms ease, transform 300ms ease',
-              }}
-            >
-              <LanguageDropdown compact id="language-select-mobile" />
-            </li>
-          </ul>
-        </div>,
-        document.body,
-      )}
+            </ul>
+          </div>,
+          document.body,
+        )}
     </>
   );
 }

--- a/components/sections/Contact.tsx
+++ b/components/sections/Contact.tsx
@@ -49,7 +49,7 @@ function ConstellationBackground() {
     delay: (i % 7) * 2,
     opacity: 0.04 + (i % 4) * 0.02,
     dx: `${((i % 3) - 1) * 8}px`,
-    dy: `${((i % 2) === 0 ? -1 : 1) * 6}px`,
+    dy: `${(i % 2 === 0 ? -1 : 1) * 6}px`,
   }));
 
   return (
@@ -58,16 +58,18 @@ function ConstellationBackground() {
         <div
           key={i}
           className="bg-parchment absolute rounded-full"
-          style={{
-            left: star.left,
-            top: star.top,
-            width: `${star.size}px`,
-            height: `${star.size}px`,
-            '--star-opacity': String(star.opacity),
-            '--star-dx': star.dx,
-            '--star-dy': star.dy,
-            animation: `star-drift ${star.duration}s ease-in-out ${star.delay}s infinite`,
-          } as React.CSSProperties}
+          style={
+            {
+              left: star.left,
+              top: star.top,
+              width: `${star.size}px`,
+              height: `${star.size}px`,
+              '--star-opacity': String(star.opacity),
+              '--star-dx': star.dx,
+              '--star-dy': star.dy,
+              animation: `star-drift ${star.duration}s ease-in-out ${star.delay}s infinite`,
+            } as React.CSSProperties
+          }
         />
       ))}
     </div>

--- a/components/sections/Education.tsx
+++ b/components/sections/Education.tsx
@@ -10,7 +10,15 @@ import { useLocaleContext } from '@/components/providers/LocaleProvider';
 import { education, certifications } from '@/data/education';
 import { trailFadeUp, waypointPop } from '@/lib/trail-animations';
 
-function EducationRow({ entry, index, isInView }: { entry: (typeof education)[number]; index: number; isInView: boolean }) {
+function EducationRow({
+  entry,
+  index,
+  isInView,
+}: {
+  entry: (typeof education)[number];
+  index: number;
+  isInView: boolean;
+}) {
   const [expanded, setExpanded] = useState(false);
   const hasDetails = entry.details.length > 0;
 
@@ -25,18 +33,22 @@ function EducationRow({ entry, index, isInView }: { entry: (typeof education)[nu
         type="button"
         onClick={() => hasDetails && setExpanded((e) => !e)}
         disabled={!hasDetails}
-        className="group flex w-full items-center gap-3 rounded-lg px-2 py-3 text-left transition-colors hover:bg-sand/50 disabled:cursor-default disabled:hover:bg-transparent"
+        className="group hover:bg-sand/50 flex w-full items-center gap-3 rounded-lg px-2 py-3 text-left transition-colors disabled:cursor-default disabled:hover:bg-transparent"
       >
         <GraduationCap className="text-gold h-5 w-5 shrink-0" />
         <div className="min-w-0 flex-1">
           <div className="flex flex-wrap items-baseline gap-x-2 gap-y-1">
             <span className="text-forest font-serif text-lg font-semibold">{entry.degree}</span>
-            <span className="text-bark text-sm" aria-hidden>—</span>
+            <span className="text-bark text-sm" aria-hidden>
+              —
+            </span>
             <span className="text-bark text-sm">{entry.institution}</span>
             {entry.field && <Badge className="text-xs">{entry.field}</Badge>}
           </div>
         </div>
-        <span className="text-stone shrink-0 text-xs tabular-nums">{entry.startYear}–{entry.endYear}</span>
+        <span className="text-stone shrink-0 text-xs tabular-nums">
+          {entry.startYear}–{entry.endYear}
+        </span>
         {hasDetails && (
           <span className="text-gold shrink-0">
             {expanded ? <ChevronUp className="h-4 w-4" /> : <ChevronDown className="h-4 w-4" />}
@@ -74,7 +86,7 @@ export function Education() {
         {messages.sections.education}
       </AnimatedHeading>
 
-      <div ref={ref} className="mt-8 divide-y divide-bark/10">
+      <div ref={ref} className="divide-bark/10 mt-8 divide-y">
         {education.map((entry, i) => (
           <EducationRow key={entry.id} entry={entry} index={i} isInView={isInView} />
         ))}

--- a/components/sections/Endorsements.test.tsx
+++ b/components/sections/Endorsements.test.tsx
@@ -29,7 +29,9 @@ describe('Endorsements', () => {
     expect(screen.getAllByText('Kimball Heaton').length).toBeGreaterThanOrEqual(1);
     expect(screen.getAllByText('Katherine Liu').length).toBeGreaterThanOrEqual(1);
     expect(screen.getAllByText('Lia Young').length).toBeGreaterThanOrEqual(1);
-    expect(screen.getAllByLabelText(/View this recommendation on LinkedIn/i).length).toBeGreaterThanOrEqual(3);
+    expect(
+      screen.getAllByLabelText(/View this recommendation on LinkedIn/i).length,
+    ).toBeGreaterThanOrEqual(3);
   });
 
   it('has the endorsements section id', () => {

--- a/components/sections/Endorsements.tsx
+++ b/components/sections/Endorsements.tsx
@@ -155,7 +155,7 @@ export function Endorsements() {
           {/* Desktop: auto-scrolling marquee */}
           <div className="hidden overflow-hidden md:block">
             <div
-              className="flex hover:[animation-play-state:paused] focus-within:[animation-play-state:paused]"
+              className="flex focus-within:[animation-play-state:paused] hover:[animation-play-state:paused]"
               style={{
                 animation: prefersReducedMotion
                   ? 'none'
@@ -179,7 +179,7 @@ export function Endorsements() {
           {/* Mobile: horizontal scroll with snap */}
           <div
             ref={scrollRef}
-            className="scrollbar-none -mx-4 flex snap-x snap-mandatory gap-0 overflow-x-auto px-4 md:hidden"
+            className="-mx-4 flex snap-x snap-mandatory scrollbar-none gap-0 overflow-x-auto px-4 md:hidden"
           >
             {endorsements.map((endorsement, i) => (
               <div key={endorsement.id} className="snap-center">

--- a/components/sections/Experience.tsx
+++ b/components/sections/Experience.tsx
@@ -199,7 +199,15 @@ function CardContent({
 }
 
 /** Trail profile / elevation-style line (abstract "path" for this role) */
-function TrailProfileGraph({ count, id, className }: { count: number; id: string; className?: string }) {
+function TrailProfileGraph({
+  count,
+  id,
+  className,
+}: {
+  count: number;
+  id: string;
+  className?: string;
+}) {
   const points = 8;
   const steps = Array.from({ length: points }, (_, i) => {
     const t = i / (points - 1);
@@ -318,9 +326,10 @@ export function Experience() {
 
   const featuredExperiences = experiences.filter((e) => e.featured);
   const olderExperiences = experiences.filter((e) => !e.featured);
-  const olderDateRange = olderExperiences.length > 0
-    ? `${olderExperiences[olderExperiences.length - 1].startDate.split(' ')[1]}–${olderExperiences[0].endDate === 'Present' ? 'Present' : olderExperiences[0].endDate.split(' ')[1]}`
-    : '';
+  const olderDateRange =
+    olderExperiences.length > 0
+      ? `${olderExperiences[olderExperiences.length - 1].startDate.split(' ')[1]}–${olderExperiences[0].endDate === 'Present' ? 'Present' : olderExperiences[0].endDate.split(' ')[1]}`
+      : '';
 
   return (
     <Section variant="light" id="experience" mapFrame nature={{ leaves: true, pines: true }}>
@@ -356,9 +365,7 @@ export function Experience() {
           >
             <span className="font-medium">
               {showHistory ? '▾' : '▸'}{' '}
-              {showHistory
-                ? messages.experience.hideHistory
-                : messages.experience.viewFullHistory}
+              {showHistory ? messages.experience.hideHistory : messages.experience.viewFullHistory}
             </span>
             <span className="text-stone text-sm">
               {olderExperiences.length} {messages.experience.earlierRoles} · {olderDateRange}

--- a/components/sections/Hero.tsx
+++ b/components/sections/Hero.tsx
@@ -88,7 +88,11 @@ function MountainBackdrop({ prefersReducedMotion }: { prefersReducedMotion: bool
         <m.path
           d="M0 200 L0 120 L100 80 L200 110 L300 60 L400 100 L500 50 L600 90 L700 40 L800 85 L900 55 L1000 95 L1100 70 L1200 100 L1200 200Z"
           fill="rgba(245,240,232,0.06)"
-          style={prefersReducedMotion ? undefined : { animation: 'mountain-sway-far 10s ease-in-out infinite' }}
+          style={
+            prefersReducedMotion
+              ? undefined
+              : { animation: 'mountain-sway-far 10s ease-in-out infinite' }
+          }
           {...(prefersReducedMotion
             ? {}
             : {
@@ -101,7 +105,11 @@ function MountainBackdrop({ prefersReducedMotion }: { prefersReducedMotion: bool
         <m.path
           d="M0 200 L0 150 L80 120 L160 145 L260 100 L340 135 L450 90 L540 130 L650 105 L740 140 L840 110 L940 145 L1050 120 L1140 150 L1200 135 L1200 200Z"
           fill="rgba(245,240,232,0.10)"
-          style={prefersReducedMotion ? undefined : { animation: 'mountain-sway-near 8s ease-in-out infinite' }}
+          style={
+            prefersReducedMotion
+              ? undefined
+              : { animation: 'mountain-sway-near 8s ease-in-out infinite' }
+          }
           {...(prefersReducedMotion
             ? {}
             : {
@@ -114,7 +122,11 @@ function MountainBackdrop({ prefersReducedMotion }: { prefersReducedMotion: bool
         <m.path
           d="M0 200 L0 170 L20 168 L35 155 L38 168 L55 150 L58 168 L75 158 L78 168 L95 145 L98 168 L120 160 L140 148 L143 168 L165 155 L168 168 L190 162 L210 142 L213 168 L240 158 L260 148 L263 168 L285 155 L305 140 L308 168 L330 160 L350 150 L353 168 L375 155 L395 145 L398 168 L420 160 L440 152 L443 168 L465 155 L485 142 L488 168 L510 158 L530 148 L533 168 L555 155 L575 140 L578 168 L600 162 L620 150 L623 168 L645 155 L665 145 L668 168 L690 160 L710 148 L713 168 L735 155 L755 142 L758 168 L780 160 L800 150 L803 168 L825 155 L845 145 L848 168 L870 160 L890 152 L893 168 L915 155 L935 142 L938 168 L960 158 L980 148 L983 168 L1005 155 L1025 140 L1028 168 L1050 162 L1070 150 L1073 168 L1095 155 L1115 145 L1118 168 L1140 160 L1160 152 L1163 168 L1185 158 L1200 165 L1200 200Z"
           fill="rgba(245,240,232,0.08)"
-          style={prefersReducedMotion ? undefined : { animation: 'mountain-sway-tree 12s ease-in-out infinite' }}
+          style={
+            prefersReducedMotion
+              ? undefined
+              : { animation: 'mountain-sway-tree 12s ease-in-out infinite' }
+          }
           {...(prefersReducedMotion
             ? {}
             : {
@@ -255,29 +267,133 @@ export function Hero() {
 
           {/* Elevation contour hints */}
           {/* Contour group A — upper right */}
-          <g style={prefersReducedMotion ? undefined : { animation: 'contour-drift-a 15s ease-in-out infinite' }}>
-            <ellipse cx="560" cy="140" rx="90" ry="45" fill="none" stroke="rgba(245,240,232,0.12)" strokeWidth="0.8" />
-            <ellipse cx="560" cy="140" rx="65" ry="32" fill="none" stroke="rgba(245,240,232,0.10)" strokeWidth="0.8" />
-            <ellipse cx="560" cy="140" rx="40" ry="20" fill="none" stroke="rgba(245,240,232,0.08)" strokeWidth="0.8" />
+          <g
+            style={
+              prefersReducedMotion
+                ? undefined
+                : { animation: 'contour-drift-a 15s ease-in-out infinite' }
+            }
+          >
+            <ellipse
+              cx="560"
+              cy="140"
+              rx="90"
+              ry="45"
+              fill="none"
+              stroke="rgba(245,240,232,0.12)"
+              strokeWidth="0.8"
+            />
+            <ellipse
+              cx="560"
+              cy="140"
+              rx="65"
+              ry="32"
+              fill="none"
+              stroke="rgba(245,240,232,0.10)"
+              strokeWidth="0.8"
+            />
+            <ellipse
+              cx="560"
+              cy="140"
+              rx="40"
+              ry="20"
+              fill="none"
+              stroke="rgba(245,240,232,0.08)"
+              strokeWidth="0.8"
+            />
           </g>
 
           {/* Contour group B — lower left */}
-          <g style={prefersReducedMotion ? undefined : { animation: 'contour-drift-b 18s ease-in-out infinite' }}>
-            <ellipse cx="200" cy="420" rx="70" ry="35" fill="none" stroke="rgba(245,240,232,0.10)" strokeWidth="0.8" />
-            <ellipse cx="200" cy="420" rx="50" ry="25" fill="none" stroke="rgba(245,240,232,0.08)" strokeWidth="0.8" />
-            <ellipse cx="200" cy="420" rx="30" ry="15" fill="none" stroke="rgba(245,240,232,0.06)" strokeWidth="0.8" />
+          <g
+            style={
+              prefersReducedMotion
+                ? undefined
+                : { animation: 'contour-drift-b 18s ease-in-out infinite' }
+            }
+          >
+            <ellipse
+              cx="200"
+              cy="420"
+              rx="70"
+              ry="35"
+              fill="none"
+              stroke="rgba(245,240,232,0.10)"
+              strokeWidth="0.8"
+            />
+            <ellipse
+              cx="200"
+              cy="420"
+              rx="50"
+              ry="25"
+              fill="none"
+              stroke="rgba(245,240,232,0.08)"
+              strokeWidth="0.8"
+            />
+            <ellipse
+              cx="200"
+              cy="420"
+              rx="30"
+              ry="15"
+              fill="none"
+              stroke="rgba(245,240,232,0.06)"
+              strokeWidth="0.8"
+            />
           </g>
 
           {/* Contour group C — center */}
-          <g style={prefersReducedMotion ? undefined : { animation: 'contour-drift-c 20s ease-in-out infinite' }}>
-            <ellipse cx="470" cy="350" rx="60" ry="30" fill="none" stroke="rgba(245,240,232,0.10)" strokeWidth="0.8" />
-            <ellipse cx="470" cy="350" rx="38" ry="18" fill="none" stroke="rgba(245,240,232,0.08)" strokeWidth="0.8" />
+          <g
+            style={
+              prefersReducedMotion
+                ? undefined
+                : { animation: 'contour-drift-c 20s ease-in-out infinite' }
+            }
+          >
+            <ellipse
+              cx="470"
+              cy="350"
+              rx="60"
+              ry="30"
+              fill="none"
+              stroke="rgba(245,240,232,0.10)"
+              strokeWidth="0.8"
+            />
+            <ellipse
+              cx="470"
+              cy="350"
+              rx="38"
+              ry="18"
+              fill="none"
+              stroke="rgba(245,240,232,0.08)"
+              strokeWidth="0.8"
+            />
           </g>
 
           {/* Contour group D — upper left */}
-          <g style={prefersReducedMotion ? undefined : { animation: 'contour-drift-a 14s ease-in-out infinite 3s' }}>
-            <ellipse cx="130" cy="180" rx="55" ry="28" fill="none" stroke="rgba(245,240,232,0.08)" strokeWidth="0.8" />
-            <ellipse cx="130" cy="180" rx="35" ry="18" fill="none" stroke="rgba(245,240,232,0.06)" strokeWidth="0.8" />
+          <g
+            style={
+              prefersReducedMotion
+                ? undefined
+                : { animation: 'contour-drift-a 14s ease-in-out infinite 3s' }
+            }
+          >
+            <ellipse
+              cx="130"
+              cy="180"
+              rx="55"
+              ry="28"
+              fill="none"
+              stroke="rgba(245,240,232,0.08)"
+              strokeWidth="0.8"
+            />
+            <ellipse
+              cx="130"
+              cy="180"
+              rx="35"
+              ry="18"
+              fill="none"
+              stroke="rgba(245,240,232,0.06)"
+              strokeWidth="0.8"
+            />
           </g>
 
           {/* Secondary trail paths (dotted, decoration) */}

--- a/components/sections/Services.tsx
+++ b/components/sections/Services.tsx
@@ -22,8 +22,20 @@ const iconMap: Record<string, LucideIcon> = {
 function CodeBracketsIllustration() {
   return (
     <svg viewBox="0 0 80 80" className="h-20 w-20 opacity-[0.08]" aria-hidden>
-      <path d="M25 15 L10 40 L25 65" fill="none" stroke="currentColor" strokeWidth="3" strokeLinecap="round" />
-      <path d="M55 15 L70 40 L55 65" fill="none" stroke="currentColor" strokeWidth="3" strokeLinecap="round" />
+      <path
+        d="M25 15 L10 40 L25 65"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="3"
+        strokeLinecap="round"
+      />
+      <path
+        d="M55 15 L70 40 L55 65"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="3"
+        strokeLinecap="round"
+      />
       <line x1="35" y1="10" x2="45" y2="70" stroke="currentColor" strokeWidth="2" opacity="0.6" />
     </svg>
   );
@@ -55,7 +67,12 @@ function ConnectedUsersIllustration() {
 function PaletteIllustration() {
   return (
     <svg viewBox="0 0 80 80" className="h-20 w-20 opacity-[0.08]" aria-hidden>
-      <path d="M40 10 C55 10 70 25 70 40 C70 55 55 70 40 70 C25 70 10 55 10 40 C10 25 25 10 40 10" fill="none" stroke="currentColor" strokeWidth="2" />
+      <path
+        d="M40 10 C55 10 70 25 70 40 C70 55 55 70 40 70 C25 70 10 55 10 40 C10 25 25 10 40 10"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="2"
+      />
       <circle cx="30" cy="30" r="4" fill="currentColor" opacity="0.5" />
       <circle cx="50" cy="28" r="3" fill="currentColor" opacity="0.4" />
       <circle cx="55" cy="45" r="3.5" fill="currentColor" opacity="0.45" />
@@ -111,10 +128,7 @@ export function Services() {
               className="relative flex flex-col items-start gap-6 md:flex-row md:items-center"
             >
               {/* Icon + illustration side */}
-              <div className={cn(
-                'flex shrink-0 items-center gap-4',
-                !isEven && 'md:order-2',
-              )}>
+              <div className={cn('flex shrink-0 items-center gap-4', !isEven && 'md:order-2')}>
                 <div className="bg-gold/10 flex h-12 w-12 items-center justify-center rounded-full">
                   {Icon && <Icon className="text-gold h-6 w-6" />}
                 </div>

--- a/components/ui/Card.tsx
+++ b/components/ui/Card.tsx
@@ -12,7 +12,7 @@ export function Card({ children, className, variant = 'default' }: CardProps) {
     <div
       className={cn(
         'group/card border-bark/10 bg-sand/40 hover:border-gold/30 relative rounded-lg border p-6 backdrop-blur-sm transition-all duration-500 hover:-translate-y-1 hover:shadow-[0_4px_24px_rgba(107,127,94,0.12),0_1px_8px_rgba(184,134,11,0.08)]',
-        'after:pointer-events-none after:absolute after:inset-0 after:rounded-lg after:content-[\'\'] after:opacity-0 after:transition-opacity hover:after:animate-[topo-pulse_0.6s_ease-out]',
+        "after:pointer-events-none after:absolute after:inset-0 after:rounded-lg after:opacity-0 after:transition-opacity after:content-[''] hover:after:animate-[topo-pulse_0.6s_ease-out]",
         variant === 'map' && 'border-bark/20 border-dashed',
         className,
       )}

--- a/components/ui/NatureElements.tsx
+++ b/components/ui/NatureElements.tsx
@@ -88,15 +88,17 @@ export function FloatingLeaves({
         <div
           key={leaf.id}
           className={`absolute ${color}`}
-          style={{
-            left: `${leaf.x}%`,
-            width: leaf.size,
-            height: leaf.size,
-            top: '-5%',
-            '--leaf-drift': `${leaf.drift}px`,
-            '--leaf-start-rot': `${leaf.rotation}deg`,
-            animation: `leaf-fall ${leaf.duration}s linear ${leaf.delay}s infinite`,
-          } as React.CSSProperties}
+          style={
+            {
+              left: `${leaf.x}%`,
+              width: leaf.size,
+              height: leaf.size,
+              top: '-5%',
+              '--leaf-drift': `${leaf.drift}px`,
+              '--leaf-start-rot': `${leaf.rotation}deg`,
+              animation: `leaf-fall ${leaf.duration}s linear ${leaf.delay}s infinite`,
+            } as React.CSSProperties
+          }
         >
           <LeafSVG variant={leaf.variant} />
         </div>
@@ -193,14 +195,16 @@ export function Fireflies({ count = 12 }: { count?: number }) {
         <div
           key={dot.id}
           className="bg-gold-light/30 absolute rounded-full"
-          style={{
-            left: `${dot.x}%`,
-            top: `${dot.y}%`,
-            width: dot.size,
-            height: dot.size,
-            '--firefly-drift': `${dot.drift}px`,
-            animation: `firefly-pulse ${dot.duration}s ease-in-out ${dot.delay}s infinite`,
-          } as React.CSSProperties}
+          style={
+            {
+              left: `${dot.x}%`,
+              top: `${dot.y}%`,
+              width: dot.size,
+              height: dot.size,
+              '--firefly-drift': `${dot.drift}px`,
+              animation: `firefly-pulse ${dot.duration}s ease-in-out ${dot.delay}s infinite`,
+            } as React.CSSProperties
+          }
         />
       ))}
     </div>

--- a/components/ui/ScrollProgressBar.tsx
+++ b/components/ui/ScrollProgressBar.tsx
@@ -9,15 +9,8 @@ export function ScrollProgressBar() {
   useScrollProgress();
 
   return (
-    <div
-      aria-hidden="true"
-      className="pointer-events-none fixed top-16 left-0 z-50 h-1.5 w-full"
-    >
-      <svg
-        viewBox="0 0 200 18"
-        preserveAspectRatio="none"
-        className="h-full w-full"
-      >
+    <div aria-hidden="true" className="pointer-events-none fixed top-16 left-0 z-50 h-1.5 w-full">
+      <svg viewBox="0 0 200 18" preserveAspectRatio="none" className="h-full w-full">
         {/* Track (unfilled ridge silhouette) */}
         <path
           d={ridgePath}
@@ -37,9 +30,11 @@ export function ScrollProgressBar() {
           strokeLinejoin="round"
           pathLength={1}
           strokeDasharray={1}
-          style={{
-            strokeDashoffset: 'calc(1 - var(--scroll-progress, 0))',
-          } as React.CSSProperties}
+          style={
+            {
+              strokeDashoffset: 'calc(1 - var(--scroll-progress, 0))',
+            } as React.CSSProperties
+          }
         />
       </svg>
     </div>

--- a/components/ui/TrailWaypoints.tsx
+++ b/components/ui/TrailWaypoints.tsx
@@ -68,7 +68,9 @@ export function TrailWaypoints() {
                 stroke={isActive ? 'var(--color-gold)' : 'rgba(184,134,11,0.3)'}
                 strokeWidth="1.5"
                 className={cn('transition-all duration-300')}
-                style={isActive ? { filter: 'drop-shadow(0 0 4px rgba(184,134,11,0.5))' } : undefined}
+                style={
+                  isActive ? { filter: 'drop-shadow(0 0 4px rgba(184,134,11,0.5))' } : undefined
+                }
               />
             </svg>
           </div>

--- a/data/services.ts
+++ b/data/services.ts
@@ -11,7 +11,7 @@ export const services: ServiceEntry[] = [
     title: 'Technical Product Strategy',
     icon: 'compass',
     description:
-      'I own the roadmap from discovery to delivery, balancing technical constraints with business outcomes. I\'ve consolidated 400+ backlog items into structured projects and built dual roadmaps spanning multiple teams.',
+      "I own the roadmap from discovery to delivery, balancing technical constraints with business outcomes. I've consolidated 400+ backlog items into structured projects and built dual roadmaps spanning multiple teams.",
   },
   {
     id: 'ai-augmented-engineering',
@@ -25,7 +25,7 @@ export const services: ServiceEntry[] = [
     title: 'Process & Delivery',
     icon: 'users',
     description:
-      'Certified ScrumMaster who builds the sprint cadence, retros, and cross-functional rhythms that let teams ship reliably. I\'ve designed hiring processes adopted company-wide.',
+      "Certified ScrumMaster who builds the sprint cadence, retros, and cross-functional rhythms that let teams ship reliably. I've designed hiring processes adopted company-wide.",
   },
   {
     id: 'engineering-product-bridge',

--- a/docs/superpowers/plans/2026-06-21-text-to-visual-trim.md
+++ b/docs/superpowers/plans/2026-06-21-text-to-visual-trim.md
@@ -23,6 +23,7 @@
 ### Task 1: About — Stats Row
 
 **Files:**
+
 - Modify: `messages/en.json`
 - Modify: `messages/es.json`
 - Modify: `messages/de.json`
@@ -32,6 +33,7 @@
 - Modify: `components/sections/About.tsx`
 
 **Interfaces:**
+
 - Consumes: `messages.about.body` (changed from 2-element to 1-element array), `messages.about.stats` (new), `messages.about.personalNote` (new)
 - Produces: No exports consumed by other tasks
 
@@ -254,6 +256,7 @@ git commit -m "feat(about): replace paragraph 2 with stats grid and personal clo
 ### Task 2: Experience — Featured Roles + Collapsible History
 
 **Files:**
+
 - Modify: `data/experience.ts`
 - Modify: `components/sections/Experience.tsx`
 - Modify: `messages/en.json`
@@ -264,6 +267,7 @@ git commit -m "feat(about): replace paragraph 2 with stats grid and personal clo
 - Modify: `messages/zh.json`
 
 **Interfaces:**
+
 - Consumes: `ExperienceEntry` type (adding `featured` field), `AutoHeight` component from `@/components/ui/AutoHeight`
 - Produces: No exports consumed by other tasks
 
@@ -293,6 +297,7 @@ Then add `featured: true` to the circadence, starbucks, stellarfi, and sana-bene
 Add to the `experience` object in each locale file:
 
 **en.json:**
+
 ```json
 "experience": {
   "more": "more",
@@ -302,6 +307,7 @@ Add to the `experience` object in each locale file:
 ```
 
 **es.json:**
+
 ```json
 "experience": {
   "more": "más",
@@ -311,6 +317,7 @@ Add to the `experience` object in each locale file:
 ```
 
 **de.json:**
+
 ```json
 "experience": {
   "more": "weitere",
@@ -320,6 +327,7 @@ Add to the `experience` object in each locale file:
 ```
 
 **it.json:**
+
 ```json
 "experience": {
   "more": "altri",
@@ -329,6 +337,7 @@ Add to the `experience` object in each locale file:
 ```
 
 **ja.json:**
+
 ```json
 "experience": {
   "more": "件",
@@ -338,6 +347,7 @@ Add to the `experience` object in each locale file:
 ```
 
 **zh.json:**
+
 ```json
 "experience": {
   "more": "更多",
@@ -353,11 +363,13 @@ Three changes to this file:
 **Change A:** In the `CardContent` component, cap inline bullets at 3. Find the `<ul>` that maps `entry.description` and change the map to `.slice(0, 3)`:
 
 Replace:
+
 ```tsx
         {entry.description.map((item, i) => (
 ```
 
 With:
+
 ```tsx
         {entry.description.slice(0, 3).map((item, i) => (
 ```
@@ -390,9 +402,10 @@ export function Experience() {
 
   const featuredExperiences = experiences.filter((e) => e.featured);
   const olderExperiences = experiences.filter((e) => !e.featured);
-  const olderDateRange = olderExperiences.length > 0
-    ? `${olderExperiences[olderExperiences.length - 1].startDate.split(' ')[1]}–${olderExperiences[0].endDate === 'Present' ? 'Present' : olderExperiences[0].endDate.split(' ')[1]}`
-    : '';
+  const olderDateRange =
+    olderExperiences.length > 0
+      ? `${olderExperiences[olderExperiences.length - 1].startDate.split(' ')[1]}–${olderExperiences[0].endDate === 'Present' ? 'Present' : olderExperiences[0].endDate.split(' ')[1]}`
+      : '';
 
   return (
     <Section variant="light" id="experience" mapFrame nature={{ leaves: true, pines: true }}>
@@ -428,9 +441,7 @@ export function Experience() {
           >
             <span className="font-medium">
               {showHistory ? '▾' : '▸'}{' '}
-              {showHistory
-                ? messages.experience.hideHistory
-                : messages.experience.viewFullHistory}
+              {showHistory ? messages.experience.hideHistory : messages.experience.viewFullHistory}
             </span>
             <span className="text-stone text-sm">
               {olderExperiences.length} earlier roles · {olderDateRange}
@@ -481,6 +492,7 @@ git commit -m "feat(experience): show 4 featured roles, collapse 7 older behind 
 ### Task 3: Skills — Grouped Chip Grid
 
 **Files:**
+
 - Modify: `data/skills.ts`
 - Modify: `components/sections/Skills.tsx`
 - Modify: `messages/en.json`
@@ -491,12 +503,14 @@ git commit -m "feat(experience): show 4 featured roles, collapse 7 older behind 
 - Modify: `messages/zh.json`
 
 **Interfaces:**
+
 - Consumes: `skillCategories` from `data/skills.ts` (shape unchanged), `messages.skills.intro` (updated text)
 - Produces: No exports consumed by other tasks
 
 - [ ] **Step 1: Trim Practices category in `data/skills.ts`**
 
 In the `practices` category, make these changes:
+
 - Rename `'Technical Product Management'` → `'Product Management'`
 - Remove the `{ name: 'Stakeholder Communication', years: 1 }` entry
 - Remove the `{ name: 'Roadmap Ownership', years: 1 }` entry
@@ -524,6 +538,7 @@ The resulting practices skills array should be:
 Replace `skills.intro` and remove `skills.scaleDescription`, `skills.yearAbbrev`, `skills.yearAbbrevPlural` from each locale file. The `skills` object should have only `intro` as its key.
 
 **en.json:**
+
 ```json
 "skills": {
   "intro": "The tools and practices I reach for — trail-tested and production-ready."
@@ -531,6 +546,7 @@ Replace `skills.intro` and remove `skills.scaleDescription`, `skills.yearAbbrev`
 ```
 
 **es.json:**
+
 ```json
 "skills": {
   "intro": "Las herramientas y prácticas que uso — probadas en el camino y listas para producción."
@@ -538,6 +554,7 @@ Replace `skills.intro` and remove `skills.scaleDescription`, `skills.yearAbbrev`
 ```
 
 **de.json:**
+
 ```json
 "skills": {
   "intro": "Die Werkzeuge und Praktiken, auf die ich setze — wegerprobt und produktionsreif."
@@ -545,6 +562,7 @@ Replace `skills.intro` and remove `skills.scaleDescription`, `skills.yearAbbrev`
 ```
 
 **it.json:**
+
 ```json
 "skills": {
   "intro": "Gli strumenti e le pratiche che utilizzo — testati sul campo e pronti per la produzione."
@@ -552,6 +570,7 @@ Replace `skills.intro` and remove `skills.scaleDescription`, `skills.yearAbbrev`
 ```
 
 **ja.json:**
+
 ```json
 "skills": {
   "intro": "実践で選ぶツールとプラクティス — 実戦で試され、本番対応済み。"
@@ -559,6 +578,7 @@ Replace `skills.intro` and remove `skills.scaleDescription`, `skills.yearAbbrev`
 ```
 
 **zh.json:**
+
 ```json
 "skills": {
   "intro": "我常用的工具和实践 —— 经实战验证，可用于生产环境。"
@@ -642,9 +662,11 @@ git commit -m "feat(skills): replace proficiency bars with grouped chip grid"
 ### Task 4: Visual Verification
 
 **Files:**
+
 - No file changes — this is a verification task
 
 **Interfaces:**
+
 - Consumes: All changes from Tasks 1-3
 
 - [ ] **Step 1: Start dev server and take screenshots**
@@ -664,6 +686,7 @@ Take screenshots at 360px (mobile) and 1280px (desktop) of the About, Experience
 - [ ] **Step 2: Spot-check a non-Latin locale**
 
 Navigate to `/ja` or `/zh` and verify:
+
 - Stats grid values render correctly (e.g. `10年+` in Japanese)
 - Skills chips render with correct text
 - Experience expandable button text is translated
@@ -671,6 +694,7 @@ Navigate to `/ja` or `/zh` and verify:
 - [ ] **Step 3: Test reduced motion**
 
 In Chrome DevTools → Rendering → check "Emulate CSS prefers-reduced-motion: reduce". Reload. Verify:
+
 - Stats cards appear without animation
 - Experience cards appear without animation
 - Skills chips appear without animation

--- a/docs/superpowers/specs/2026-06-21-text-to-visual-trim-design.md
+++ b/docs/superpowers/specs/2026-06-21-text-to-visual-trim-design.md
@@ -21,11 +21,13 @@
 ## Section 1: About — Stats Row
 
 ### Current State
+
 Two dense paragraphs (~150 words each) + focus area pills. The pull-quote first paragraph is styled nicely but the second paragraph is a wall of text that buries key facts.
 
 ### Design
 
 **Keep:**
+
 - Pull-quote first paragraph with gold left border, trimmed to **sentence 1 only**: "I'm a Technical Product Manager with a frontend engineering background, which means I own the roadmap, run the team, and can still go deep on the technical decisions that actually matter."
 - Focus area pills unchanged
 
@@ -33,29 +35,32 @@ Two dense paragraphs (~150 words each) + focus area pills. The pull-quote first 
 
 Four stat cards in a responsive grid (4 columns desktop, 2×2 mobile):
 
-| Stat | Value | Label |
-|------|-------|-------|
-| Years | `10+` | Years Building |
-| Industries | `5` | Industries |
-| Certification | `CSM` | Certified |
-| Role style | `IC↔PM` | Dual Track |
+| Stat          | Value   | Label          |
+| ------------- | ------- | -------------- |
+| Years         | `10+`   | Years Building |
+| Industries    | `5`     | Industries     |
+| Certification | `CSM`   | Certified      |
+| Role style    | `IC↔PM` | Dual Track     |
 
 Each card: gold large value text (`font-serif text-3xl font-bold text-gold`), small stone-colored label below (`text-stone text-xs`). Dashed `border-gold/30` border, `rounded-lg`. Animated entrance on scroll (staggered per card via Framer Motion).
 
 Both stat values and labels are i18n message keys so CJK locales can adjust formatting (e.g. `10+` → `10年+` in Japanese).
 
 **Add a short italic personal closer** below the stats grid:
+
 > When I'm not at my desk, I'm teaching yoga, hiking Colorado's trails, or trying to settle the Oreo debate once and for all.
 
 This is the last sentence from the current paragraph 2 — keeps the personality without the surrounding wall of text.
 
 ### i18n Impact
+
 - New message keys under `about.stats` — array of `{ value: string, label: string }` objects (4 items)
 - New message key: `about.personalNote` (the italic closer)
 - `about.body` changes from a 2-element array to a 1-element array (sentence 1 only) in all 6 locale files
 - The remaining `about.body` paragraphs and sentences 2-4 are deleted from all locale files
 
 ### Files
+
 - Modify: `components/sections/About.tsx`
 - Modify: `messages/en.json`, `messages/es.json`, `messages/de.json`, `messages/it.json`, `messages/ja.json`, `messages/zh.json`
 
@@ -64,6 +69,7 @@ This is the last sentence from the current paragraph 2 — keeps the personality
 ## Section 2: Experience — Featured Roles + Collapsible History
 
 ### Current State
+
 11 timeline entries all expanded with 2-7 bullet descriptions each. The Circadence entry alone has 7 long bullets. On desktop the alternating timeline is visually interesting but the content volume is overwhelming.
 
 ### Design
@@ -71,6 +77,7 @@ This is the last sentence from the current paragraph 2 — keeps the personality
 **Add a `featured` boolean to experience entries.** Featured roles are shown by default; non-featured roles are hidden behind an expandable.
 
 **Featured roles** (4 entries):
+
 1. Circadence (Technical Product Manager, Sep 2025–Present)
 2. Starbucks (Sr. React Developer, Feb 2024–Sep 2025)
 3. StellarFi (Senior Software Engineer, May 2023–Jan 2024)
@@ -81,6 +88,7 @@ This is the last sentence from the current paragraph 2 — keeps the personality
 **Bullet cap:** Featured roles show a maximum of 3 bullet points inline. If the data has more than 3, only the first 3 render. The data file keeps all bullets for the hover detail panel. The detail panel continues to show up to 4 bullets (its existing cap) — this is fine since the panel is opt-in on hover.
 
 **"View full trail history" expandable:**
+
 - Rendered below the last featured role's timeline card
 - Dashed `border-gold/40` border, `rounded-lg` container, padded
 - Shows: `▸ View full trail history` (gold text) + `7 earlier roles · 2015–2022` (stone text, counts and date range derived from data)
@@ -92,13 +100,16 @@ This is the last sentence from the current paragraph 2 — keeps the personality
 **Everything else unchanged:** Timeline visual, waypoint markers, alternating layout, tech badges, hover detail panel, sticky heading on mobile, trail profile graphs.
 
 ### i18n Impact
+
 - New message keys: `experience.viewFullHistory`, `experience.hideHistory`
 - Existing `experience.more` key unchanged
 
 ### Data Change
+
 Add `featured: boolean` to `ExperienceEntry` type and set it on each entry in `data/experience.ts`.
 
 ### Files
+
 - Modify: `data/experience.ts` (add `featured` field)
 - Modify: `components/sections/Experience.tsx` (filter by featured, add expandable, cap inline bullets at 3)
 - Modify: `messages/en.json`, `messages/es.json`, `messages/de.json`, `messages/it.json`, `messages/ja.json`, `messages/zh.json`
@@ -108,17 +119,20 @@ Add `featured: boolean` to `ExperienceEntry` type and set it on each entry in `d
 ## Section 3: Skills — Grouped Chip Grid
 
 ### Current State
+
 Horizontal proficiency bars sorted by years, grouped into 4 categories in a 2-column grid. Each bar has a hover-to-reveal years tooltip. ~28 skills total across 4 categories creates a long vertical scroll, especially on mobile.
 
 ### Design
 
 **Replace proficiency bars with a chip grid:**
+
 - Each skill renders as a rounded chip: `bg-moss/20 border border-moss/30 rounded-md px-3 py-1.5 text-sm text-parchment/85`
 - Chips wrap in a flex container per category
 - 4 categories displayed in a 2-column grid on desktop (`md:grid-cols-2`), single column on mobile
 - Category heading: gold uppercase label (`text-gold text-sm font-semibold tracking-wider uppercase`)
 
 **Remove:**
+
 - Proficiency bars
 - Years tooltip on hover
 - The `.sort((a, b) => b.years - a.years)` ordering (chips don't need proficiency ordering — keep data file order)
@@ -127,6 +141,7 @@ Horizontal proficiency bars sorted by years, grouped into 4 categories in a 2-co
 - The `maxYearsForScale` import in the component (keep export in `data/skills.ts` for backwards compat)
 
 **Keep:**
+
 - Dark section variant with contour texture background and fireflies nature element
 - Staggered entrance animation per category (Framer Motion fade-in)
 - Section heading and intro text (but update intro text — see below)
@@ -135,6 +150,7 @@ Horizontal proficiency bars sorted by years, grouped into 4 categories in a 2-co
 **Update intro text:** Change from "Years of hands-on experience with each technology — trail-tested and production-ready." to something that doesn't reference "years" since the bars are gone. New text: "The tools and practices I reach for — trail-tested and production-ready." (Update in all 6 locale files.)
 
 **Consolidate Practices category:** The Practices category has redundant long-named entries. Changes:
+
 - "Technical Product Management" → "Product Management"
 - "Stakeholder Communication" → remove (covered by "Product Management")
 - "Roadmap Ownership" → remove (covered by "Product Management")
@@ -143,6 +159,7 @@ Horizontal proficiency bars sorted by years, grouped into 4 categories in a 2-co
 This trims Practices from 9 items to 7.
 
 ### Files
+
 - Modify: `components/sections/Skills.tsx` (rewrite to chip grid)
 - Modify: `data/skills.ts` (trim Practices category, rename "Technical Product Management")
 - Modify: `messages/en.json`, `messages/es.json`, `messages/de.json`, `messages/it.json`, `messages/ja.json`, `messages/zh.json` (remove `skills.scaleDescription`, `skills.yearAbbrev`, `skills.yearAbbrevPlural`; update `skills.intro`)
@@ -151,12 +168,12 @@ This trims Practices from 9 items to 7.
 
 ## Summary of Vertical Space Impact
 
-| Section | Current Height (est.) | Proposed Height (est.) | Reduction |
-|---------|----------------------|----------------------|-----------|
-| About | ~400px | ~280px | ~30% |
-| Experience | ~2800px (11 roles) | ~1200px (4 roles) + expandable | ~57% |
-| Skills | ~600px | ~300px | ~50% |
-| **Total saved** | | | **~1600px of scroll** |
+| Section         | Current Height (est.) | Proposed Height (est.)         | Reduction             |
+| --------------- | --------------------- | ------------------------------ | --------------------- |
+| About           | ~400px                | ~280px                         | ~30%                  |
+| Experience      | ~2800px (11 roles)    | ~1200px (4 roles) + expandable | ~57%                  |
+| Skills          | ~600px                | ~300px                         | ~50%                  |
+| **Total saved** |                       |                                | **~1600px of scroll** |
 
 ## Testing
 

--- a/lib/json-ld.test.ts
+++ b/lib/json-ld.test.ts
@@ -1,0 +1,26 @@
+import { describe, it, expect } from 'vitest';
+import { toJsonLd } from './json-ld';
+
+describe('toJsonLd', () => {
+  it('round-trips to the original object', () => {
+    const data = { '@type': 'Person', name: 'Zach Lamb', sameAs: ['https://example.com'] };
+    expect(JSON.parse(toJsonLd(data))).toEqual(data);
+  });
+
+  it('escapes a closing script tag so it cannot terminate the script element', () => {
+    const out = toJsonLd({ name: '</script><img src=x onerror=alert(1)>' });
+    expect(out).not.toContain('</script>');
+    expect(out).not.toContain('<');
+  });
+
+  it('preserves the escaped value semantically', () => {
+    const payload = { name: '</script>' };
+    expect(JSON.parse(toJsonLd(payload))).toEqual(payload);
+  });
+
+  it('escapes every angle bracket occurrence, not just the first', () => {
+    const out = toJsonLd({ a: '<<<', b: '<' });
+    expect(out).not.toContain('<');
+    expect(JSON.parse(out)).toEqual({ a: '<<<', b: '<' });
+  });
+});

--- a/lib/json-ld.ts
+++ b/lib/json-ld.ts
@@ -1,0 +1,21 @@
+/**
+ * Serialize a value for embedding inside a `<script type="application/ld+json">`
+ * block via dangerouslySetInnerHTML.
+ *
+ * JSON.stringify alone is not sufficient. The HTML parser ends a script element
+ * at the literal character sequence for a closing script tag, even when it
+ * appears inside a JSON string literal. A value containing that sequence would
+ * therefore break out of the script element and let everything after it be
+ * parsed as markup — the classic JSON-in-script XSS sink.
+ *
+ * Rewriting every `<` to its JSON unicode escape keeps the payload semantically
+ * identical (JSON.parse maps the escape straight back to `<`, so consumers like
+ * Google's structured-data parser see the same object) while making a closing
+ * tag unrepresentable in the emitted HTML.
+ *
+ * The inputs used today are static site config, but encoding at the sink means
+ * the safety does not depend on that staying true.
+ */
+export function toJsonLd(data: unknown): string {
+  return JSON.stringify(data).replace(/</g, '\\u003c');
+}

--- a/messages/locale-parity.test.ts
+++ b/messages/locale-parity.test.ts
@@ -20,7 +20,12 @@ function collectLeafPaths(obj: Dict, prefix = ''): string[] {
     const path = prefix ? `${prefix}.${key}` : key;
     if (value && typeof value === 'object' && !Array.isArray(value)) {
       out.push(...collectLeafPaths(value as Dict, path));
-    } else if (Array.isArray(value) && value.length > 0 && value[0] && typeof value[0] === 'object') {
+    } else if (
+      Array.isArray(value) &&
+      value.length > 0 &&
+      value[0] &&
+      typeof value[0] === 'object'
+    ) {
       // Array of objects (e.g., about.stats): recurse into each item by index.
       value.forEach((item, idx) => {
         if (item && typeof item === 'object' && !Array.isArray(item)) {
@@ -53,7 +58,12 @@ function collectLeafEntries(obj: Dict, prefix = ''): Array<[string, unknown]> {
     const path = prefix ? `${prefix}.${key}` : key;
     if (value && typeof value === 'object' && !Array.isArray(value)) {
       out.push(...collectLeafEntries(value as Dict, path));
-    } else if (Array.isArray(value) && value.length > 0 && value[0] && typeof value[0] === 'object') {
+    } else if (
+      Array.isArray(value) &&
+      value.length > 0 &&
+      value[0] &&
+      typeof value[0] === 'object'
+    ) {
       // Array of objects (e.g., about.stats): recurse into each item by index.
       value.forEach((item, idx) => {
         if (item && typeof item === 'object' && !Array.isArray(item)) {

--- a/next.config.ts
+++ b/next.config.ts
@@ -5,10 +5,11 @@ import { withSentryConfig } from '@sentry/nextjs';
 // Content Security Policy.
 // - 'unsafe-inline' is needed for styles because Next/Tailwind inject inline
 //   style attributes. We could swap to nonces once the stack supports it.
-// - 'unsafe-inline' is also required on script-src because the JSON-LD tag in
-//   [locale]/layout.tsx uses dangerouslySetInnerHTML. Inputs are fully static,
-//   so this is safe today; if user-authored content ever reaches that tag, we
-//   must move to nonced scripts.
+// - 'unsafe-inline' is required on script-src because Next's App Router emits
+//   inline bootstrap/RSC-payload scripts. The JSON-LD tag in [locale]/layout.tsx
+//   also uses dangerouslySetInnerHTML, but its payload is now encoded through
+//   lib/json-ld.ts, which escapes `<` so a closing-tag breakout is impossible
+//   regardless of what data reaches it.
 // - Vercel Analytics ships from va.vercel-scripts.com.
 // - Sentry ingest is allowed as a fallback; in practice, client-side events
 //   are tunneled through /monitoring (same-origin), so this only matters if
@@ -21,8 +22,7 @@ const csp = [
   "form-action 'self'",
   "frame-ancestors 'none'",
   // TODO(M3): Replace 'unsafe-inline' with nonces once Next.js supports
-  // per-request nonce injection for script-src. Inputs to the JSON-LD
-  // dangerouslySetInnerHTML in [locale]/layout.tsx are fully static today.
+  // per-request nonce injection for script-src.
   "script-src 'self' 'unsafe-inline' https://va.vercel-scripts.com",
   "style-src 'self' 'unsafe-inline'",
   "img-src 'self' data: blob:",

--- a/package-lock.json
+++ b/package-lock.json
@@ -71,12 +71,12 @@
       }
     },
     "node_modules/@babel/code-frame": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.0.tgz",
-      "integrity": "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.7.tgz",
+      "integrity": "sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==",
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-validator-identifier": "^7.28.5",
+        "@babel/helper-validator-identifier": "^7.29.7",
         "js-tokens": "^4.0.0",
         "picocolors": "^1.1.1"
       },
@@ -85,29 +85,29 @@
       }
     },
     "node_modules/@babel/compat-data": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.0.tgz",
-      "integrity": "sha512-T1NCJqT/j9+cn8fvkt7jtwbLBfLC/1y1c7NtCeXFRgzGTsafi68MRv8yzkYSapBnFA6L3U2VSc02ciDzoAJhJg==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.7.tgz",
+      "integrity": "sha512-locTkQyKvwIEgBzVrn8693ebc97F2U8ZHjbXwDXJ5Fn2TCpNwTlKcaKLkdHop5c/icOFE7qt7Q9JC5hnKNa6Gg==",
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/core": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.0.tgz",
-      "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.7.tgz",
+      "integrity": "sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==",
       "license": "MIT",
       "dependencies": {
-        "@babel/code-frame": "^7.29.0",
-        "@babel/generator": "^7.29.0",
-        "@babel/helper-compilation-targets": "^7.28.6",
-        "@babel/helper-module-transforms": "^7.28.6",
-        "@babel/helpers": "^7.28.6",
-        "@babel/parser": "^7.29.0",
-        "@babel/template": "^7.28.6",
-        "@babel/traverse": "^7.29.0",
-        "@babel/types": "^7.29.0",
+        "@babel/code-frame": "^7.29.7",
+        "@babel/generator": "^7.29.7",
+        "@babel/helper-compilation-targets": "^7.29.7",
+        "@babel/helper-module-transforms": "^7.29.7",
+        "@babel/helpers": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/template": "^7.29.7",
+        "@babel/traverse": "^7.29.7",
+        "@babel/types": "^7.29.7",
         "@jridgewell/remapping": "^2.3.5",
         "convert-source-map": "^2.0.0",
         "debug": "^4.1.0",
@@ -124,13 +124,13 @@
       }
     },
     "node_modules/@babel/generator": {
-      "version": "7.29.1",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.1.tgz",
-      "integrity": "sha512-qsaF+9Qcm2Qv8SRIMMscAvG4O3lJ0F1GuMo5HR/Bp02LopNgnZBC/EkbevHFeGs4ls/oPz9v+Bsmzbkbe+0dUw==",
+      "version": "7.29.8",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.8.tgz",
+      "integrity": "sha512-gZbepsdh3WDtgZKWL+vTPh71LSBrm/Y4/QDZBVCcYfmeTEEuoOYwlSy+G1StfJg+/Zy550u/3TATbm7qDbbMtg==",
       "license": "MIT",
       "dependencies": {
-        "@babel/parser": "^7.29.0",
-        "@babel/types": "^7.29.0",
+        "@babel/parser": "^7.29.8",
+        "@babel/types": "^7.29.8",
         "@jridgewell/gen-mapping": "^0.3.12",
         "@jridgewell/trace-mapping": "^0.3.28",
         "jsesc": "^3.0.2"
@@ -140,13 +140,13 @@
       }
     },
     "node_modules/@babel/helper-compilation-targets": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.28.6.tgz",
-      "integrity": "sha512-JYtls3hqi15fcx5GaSNL7SCTJ2MNmjrkHXg4FSpOA/grxK8KwyZ5bubHsCq8FXCkua6xhuaaBit+3b7+VZRfcA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.29.7.tgz",
+      "integrity": "sha512-wem6WaBj4NaVYVdNhLPPVacES6ZJ+KBBfSkTMD3YZxbP3rm3Di85tJU5ljaUNhaOynt+Aj0xruhYuzQBt8n71g==",
       "license": "MIT",
       "dependencies": {
-        "@babel/compat-data": "^7.28.6",
-        "@babel/helper-validator-option": "^7.27.1",
+        "@babel/compat-data": "^7.29.7",
+        "@babel/helper-validator-option": "^7.29.7",
         "browserslist": "^4.24.0",
         "lru-cache": "^5.1.1",
         "semver": "^6.3.1"
@@ -156,36 +156,36 @@
       }
     },
     "node_modules/@babel/helper-globals": {
-      "version": "7.28.0",
-      "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.28.0.tgz",
-      "integrity": "sha512-+W6cISkXFa1jXsDEdYA8HeevQT/FULhxzR99pxphltZcVaugps53THCeiWA8SguxxpSp3gKPiuYfSWopkLQ4hw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.29.7.tgz",
+      "integrity": "sha512-3nQVUAtvkKH9zahfWgw96Jc/uFOmjACE1kQz82E2lqWmHBgjzbNlsC22nuQTfahmWeQtTq5nQ/4Nnd2A1wj4zA==",
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-module-imports": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.28.6.tgz",
-      "integrity": "sha512-l5XkZK7r7wa9LucGw9LwZyyCUscb4x37JWTPz7swwFE/0FMQAGpiWUZn8u9DzkSBWEcK25jmvubfpw2dnAMdbw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.29.7.tgz",
+      "integrity": "sha512-ejHwrQQYcm9xnTivShn2IDOlIzInN34AXskvq9QicvCtEzq1Vzclu/tKF8Jq1Cg8JG2GL6/EmjgsCT7lXepE3g==",
       "license": "MIT",
       "dependencies": {
-        "@babel/traverse": "^7.28.6",
-        "@babel/types": "^7.28.6"
+        "@babel/traverse": "^7.29.7",
+        "@babel/types": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-module-transforms": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.28.6.tgz",
-      "integrity": "sha512-67oXFAYr2cDLDVGLXTEABjdBJZ6drElUSI7WKp70NrpyISso3plG9SAGEF6y7zbha/wOzUByWWTJvEDVNIUGcA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.29.7.tgz",
+      "integrity": "sha512-UPUVSyXbOh627KiCIGQSgwWzGeBKLkaJ9PJEdrngIwMSzxLR4jS4+f1f1jb7VzBbg8nFLaYotvVPFCTqdrmTAg==",
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-module-imports": "^7.28.6",
-        "@babel/helper-validator-identifier": "^7.28.5",
-        "@babel/traverse": "^7.28.6"
+        "@babel/helper-module-imports": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7",
+        "@babel/traverse": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -195,52 +195,52 @@
       }
     },
     "node_modules/@babel/helper-string-parser": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
-      "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.29.7.tgz",
+      "integrity": "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==",
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-validator-identifier": {
-      "version": "7.28.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
-      "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
+      "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-validator-option": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.27.1.tgz",
-      "integrity": "sha512-YvjJow9FxbhFFKDSuFnVCe2WxXk1zWc22fFePVNEaWJEu8IrZVlda6N0uHwzZrUM1il7NC9Mlp4MaJYbYd9JSg==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.29.7.tgz",
+      "integrity": "sha512-N9ZErrD+yW5geCDtBqnOoxmR8+tNKiGuxKlDpuJxfsqpa2dFcexaziGAE/qoHLiDDreVNMupxGmSoNlyvsA3gw==",
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helpers": {
-      "version": "7.29.2",
-      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.29.2.tgz",
-      "integrity": "sha512-HoGuUs4sCZNezVEKdVcwqmZN8GoHirLUcLaYVNBK2J0DadGtdcqgr3BCbvH8+XUo4NGjNl3VOtSjEKNzqfFgKw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.29.7.tgz",
+      "integrity": "sha512-1k2lAGRMfHTcwuNYcCNUmaUffmQv8KWMfh2iJUUeRlwlwH4FdNG7mfPI10NPfLHJFThE4Tyr4mv7kTNZOiPuBg==",
       "license": "MIT",
       "dependencies": {
-        "@babel/template": "^7.28.6",
-        "@babel/types": "^7.29.0"
+        "@babel/template": "^7.29.7",
+        "@babel/types": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.29.2",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.2.tgz",
-      "integrity": "sha512-4GgRzy/+fsBa72/RZVJmGKPmZu9Byn8o4MoLpmNe1m8ZfYnz5emHLQz3U4gLud6Zwl0RZIcgiLD7Uq7ySFuDLA==",
+      "version": "7.29.8",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.8.tgz",
+      "integrity": "sha512-E8lTAYNB1KW+FH+VGJuZM1ioAx2E6oVlvQFRrf5P8ZZmsiJXYAD9vTFV7yyEURNzgh1dFqMZuO6tUwcARbqFCA==",
       "license": "MIT",
       "dependencies": {
-        "@babel/types": "^7.29.0"
+        "@babel/types": "^7.29.8"
       },
       "bin": {
         "parser": "bin/babel-parser.js"
@@ -260,31 +260,31 @@
       }
     },
     "node_modules/@babel/template": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.28.6.tgz",
-      "integrity": "sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.29.7.tgz",
+      "integrity": "sha512-puq+Gf35oI24FeN11LkoUQFqv9uwNeWpxXZi/Ji3rRIoKAzKnxRaZ+Gkj0vKS9ZCiTESfng1N9LyOyXvo+m+Gg==",
       "license": "MIT",
       "dependencies": {
-        "@babel/code-frame": "^7.28.6",
-        "@babel/parser": "^7.28.6",
-        "@babel/types": "^7.28.6"
+        "@babel/code-frame": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/types": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/traverse": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.0.tgz",
-      "integrity": "sha512-4HPiQr0X7+waHfyXPZpWPfWL/J7dcN1mx9gL6WdQVMbPnF3+ZhSMs8tCxN7oHddJE9fhNE7+lxdnlyemKfJRuA==",
+      "version": "7.29.8",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.8.tgz",
+      "integrity": "sha512-I5z7H3bf/41ktsNVLtpN0wAa336HkqIHQ5BuPLEhTkt1jVSyZpeNKIzTgEWmlxjdg81R0IgUCcaE+Ok3NvrfZg==",
       "license": "MIT",
       "dependencies": {
-        "@babel/code-frame": "^7.29.0",
-        "@babel/generator": "^7.29.0",
-        "@babel/helper-globals": "^7.28.0",
-        "@babel/parser": "^7.29.0",
-        "@babel/template": "^7.28.6",
-        "@babel/types": "^7.29.0",
+        "@babel/code-frame": "^7.29.7",
+        "@babel/generator": "^7.29.8",
+        "@babel/helper-globals": "^7.29.7",
+        "@babel/parser": "^7.29.8",
+        "@babel/template": "^7.29.7",
+        "@babel/types": "^7.29.8",
         "debug": "^4.3.1"
       },
       "engines": {
@@ -292,13 +292,13 @@
       }
     },
     "node_modules/@babel/types": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
-      "integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
+      "version": "7.29.8",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.8.tgz",
+      "integrity": "sha512-Vj1jF3cPfxg7OAfoI7QnVKLoILlm2JF9pnVHrX8qx7AHMiYWT+NDAA7jChlNgRS4WTLc/fD1lXLmPixluj+3Gg==",
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-string-parser": "^7.27.1",
-        "@babel/helper-validator-identifier": "^7.28.5"
+        "@babel/helper-string-parser": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -326,9 +326,9 @@
       }
     },
     "node_modules/@emnapi/runtime": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
-      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
+      "version": "1.11.3",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.3.tgz",
+      "integrity": "sha512-Xz4Tpyki7XyrpbUK1jR1AhdAdaXyhhY4lZ3neLodmhpuWfy2PAQN5B46sAiU4liOXGLkHypn/qU+jvfWSCYYLA==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -574,9 +574,9 @@
       }
     },
     "node_modules/@img/sharp-darwin-arm64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.34.5.tgz",
-      "integrity": "sha512-imtQ3WMJXbMY4fxb/Ndp6HBTNVtWCUI0WdobyheGf5+ad6xX8VIDO8u2xE4qc/fr08CKG/7dDseFtn6M6g/r3w==",
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.35.3.tgz",
+      "integrity": "sha512-RMnFX7YQsMoh7lWfcM4NEHHymBX/rLuKNPVM84XE9ONPcaSCDgE7CHIHpSgPcO2xcRthgBy1HfNO319mwhIAkg==",
       "cpu": [
         "arm64"
       ],
@@ -586,19 +586,19 @@
         "darwin"
       ],
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-darwin-arm64": "1.2.4"
+        "@img/sharp-libvips-darwin-arm64": "1.3.2"
       }
     },
     "node_modules/@img/sharp-darwin-x64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.34.5.tgz",
-      "integrity": "sha512-YNEFAF/4KQ/PeW0N+r+aVVsoIY0/qxxikF2SWdp+NRkmMB7y9LBZAVqQ4yhGCm/H3H270OSykqmQMKLBhBJDEw==",
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.35.3.tgz",
+      "integrity": "sha512-Xo+5uFBtLN0BKqieTxiFzFPQAUlBbbH5iBKyRX/z1JrbnYsHTfKJnUfL8+p2TPXr1pXqao4eeL4Rl144uDpK9w==",
       "cpu": [
         "x64"
       ],
@@ -608,19 +608,38 @@
         "darwin"
       ],
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-darwin-x64": "1.2.4"
+        "@img/sharp-libvips-darwin-x64": "1.3.2"
+      }
+    },
+    "node_modules/@img/sharp-freebsd-wasm32": {
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-freebsd-wasm32/-/sharp-freebsd-wasm32-0.35.3.tgz",
+      "integrity": "sha512-lUxcqWIj2wMQ9BrwNjngcr1gWUr5xgaGThBRqPPalIC2n67Cqj1uPh8NnA/ZhAg8hUbKl+kVHKwgUIwe6ZYPrg==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "dependencies": {
+        "@img/sharp-wasm32": "0.35.3"
+      },
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
       }
     },
     "node_modules/@img/sharp-libvips-darwin-arm64": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.2.4.tgz",
-      "integrity": "sha512-zqjjo7RatFfFoP0MkQ51jfuFZBnVE2pRiaydKJ1G/rHZvnsrHAOcQALIi9sA5co5xenQdTugCvtb1cuf78Vf4g==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.3.2.tgz",
+      "integrity": "sha512-9J6ypZFpQBj4YnePGoq/S38w6nz+vqg5WZLrLGY4YuSemdMq47GMLBPO42MzwdGwpg/agZ7xzZcFHa48xlywfg==",
       "cpu": [
         "arm64"
       ],
@@ -634,9 +653,9 @@
       }
     },
     "node_modules/@img/sharp-libvips-darwin-x64": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.2.4.tgz",
-      "integrity": "sha512-1IOd5xfVhlGwX+zXv2N93k0yMONvUlANylbJw1eTah8K/Jtpi15KC+WSiaX/nBmbm2HxRM1gZ0nSdjSsrZbGKg==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.3.2.tgz",
+      "integrity": "sha512-m2pW1n6cns9VaubNwsZ+c3CRYjxNQWgJ5gPlnL1nbBcpkBvFm6SCFN5o0psFHI8w9n11NKhFkeEDns98tiqbEw==",
       "cpu": [
         "x64"
       ],
@@ -650,9 +669,9 @@
       }
     },
     "node_modules/@img/sharp-libvips-linux-arm": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.2.4.tgz",
-      "integrity": "sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.3.2.tgz",
+      "integrity": "sha512-1eMLzy92I4J6rmi4mAT8yC3HxOtniyGELlzGbNMLLeqe052ahFQ0h6LFq+lh5DsDIdYViIDst08abvSbcEdLXQ==",
       "cpu": [
         "arm"
       ],
@@ -666,9 +685,9 @@
       }
     },
     "node_modules/@img/sharp-libvips-linux-arm64": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.2.4.tgz",
-      "integrity": "sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.3.2.tgz",
+      "integrity": "sha512-dqVSFynCox4C/J8kT16V7SIFAns0IjgLwkvYT7p8LQVmJ5OS5b6tI9IGflxTeuBS//zXeFIUbwt5dwxyZ17cnA==",
       "cpu": [
         "arm64"
       ],
@@ -682,9 +701,9 @@
       }
     },
     "node_modules/@img/sharp-libvips-linux-ppc64": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-ppc64/-/sharp-libvips-linux-ppc64-1.2.4.tgz",
-      "integrity": "sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-ppc64/-/sharp-libvips-linux-ppc64-1.3.2.tgz",
+      "integrity": "sha512-3z0NHDxD6n5I9gc05U1eW1AyRm+Gznzq3naMrthPNqE6oYykcogW0l/jfpJdjYnuNl8R7yI9pNbE1XiUeyq0Aw==",
       "cpu": [
         "ppc64"
       ],
@@ -698,9 +717,9 @@
       }
     },
     "node_modules/@img/sharp-libvips-linux-riscv64": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-riscv64/-/sharp-libvips-linux-riscv64-1.2.4.tgz",
-      "integrity": "sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-riscv64/-/sharp-libvips-linux-riscv64-1.3.2.tgz",
+      "integrity": "sha512-bsb4rI+NldGOsXuej2r8OdSS8+zXDVaCWxyWrcv6kneTOlgAHtZABRzBBCwdsPiD90J4myNJuHpg6kA20ImW/w==",
       "cpu": [
         "riscv64"
       ],
@@ -714,9 +733,9 @@
       }
     },
     "node_modules/@img/sharp-libvips-linux-s390x": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-s390x/-/sharp-libvips-linux-s390x-1.2.4.tgz",
-      "integrity": "sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-s390x/-/sharp-libvips-linux-s390x-1.3.2.tgz",
+      "integrity": "sha512-/ABshyj8gCpyIrNXnHn4LorDJ0HHm1VhXPBlxZ8zAtfVPAaSafXPGn+sUSIRiwaSBy0mmFjSjiXI5mkcwdChKQ==",
       "cpu": [
         "s390x"
       ],
@@ -730,9 +749,9 @@
       }
     },
     "node_modules/@img/sharp-libvips-linux-x64": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.2.4.tgz",
-      "integrity": "sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.3.2.tgz",
+      "integrity": "sha512-ITPEtgffGJ0S6G9dRyw/366tJQqFRcHWPHhC+Stpg3Z8AEMrDrTr2lhdz4f/Y/HMbRh//7Z5mBzEpVdi62Oc3w==",
       "cpu": [
         "x64"
       ],
@@ -746,9 +765,9 @@
       }
     },
     "node_modules/@img/sharp-libvips-linuxmusl-arm64": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.2.4.tgz",
-      "integrity": "sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.3.2.tgz",
+      "integrity": "sha512-zE9EdiUzUmg5mDT5a1rk5fYJ6GWPloTwWBYDS14naqHsL+EaMpDj1AWnpLgh3u0YCORv2Tt50wrcrpYqkP97Kw==",
       "cpu": [
         "arm64"
       ],
@@ -762,9 +781,9 @@
       }
     },
     "node_modules/@img/sharp-libvips-linuxmusl-x64": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.2.4.tgz",
-      "integrity": "sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.3.2.tgz",
+      "integrity": "sha512-m0lrLiUt+lBYnCFr8qV/65yMR4E/c7/wf78I5eKTdkEakFAlZ9QlzEM3QIhhAwVeUhLAHLcCq7a7Vszq/oFNZQ==",
       "cpu": [
         "x64"
       ],
@@ -778,9 +797,9 @@
       }
     },
     "node_modules/@img/sharp-linux-arm": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm/-/sharp-linux-arm-0.34.5.tgz",
-      "integrity": "sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==",
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm/-/sharp-linux-arm-0.35.3.tgz",
+      "integrity": "sha512-affVWCTLooy8TSxbDx2qkzuDeaWLNVBA+P//FNBirHsXpP2fuBhk5AuboYUnrDnzoXes8GFjpTx0SBFOCRg+FA==",
       "cpu": [
         "arm"
       ],
@@ -790,19 +809,19 @@
         "linux"
       ],
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linux-arm": "1.2.4"
+        "@img/sharp-libvips-linux-arm": "1.3.2"
       }
     },
     "node_modules/@img/sharp-linux-arm64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.34.5.tgz",
-      "integrity": "sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==",
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.35.3.tgz",
+      "integrity": "sha512-QgKDspHPnrU+GQ55XPhGwyhC8acLVOOSyAvo1oVfFmrIXLkDNmGWzAfDZ4xK8oSA1qBQrALcHX0G5UZni/SuFQ==",
       "cpu": [
         "arm64"
       ],
@@ -812,19 +831,19 @@
         "linux"
       ],
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linux-arm64": "1.2.4"
+        "@img/sharp-libvips-linux-arm64": "1.3.2"
       }
     },
     "node_modules/@img/sharp-linux-ppc64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-ppc64/-/sharp-linux-ppc64-0.34.5.tgz",
-      "integrity": "sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==",
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-ppc64/-/sharp-linux-ppc64-0.35.3.tgz",
+      "integrity": "sha512-sMd8rDxmpLOwv/7N44klFjOD5DUO7FLdjiXDI0hoxYaf7Ar262dQIEkosE98bps+5HPLtp/EvNqeqQtOycP/IA==",
       "cpu": [
         "ppc64"
       ],
@@ -834,19 +853,19 @@
         "linux"
       ],
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linux-ppc64": "1.2.4"
+        "@img/sharp-libvips-linux-ppc64": "1.3.2"
       }
     },
     "node_modules/@img/sharp-linux-riscv64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-riscv64/-/sharp-linux-riscv64-0.34.5.tgz",
-      "integrity": "sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==",
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-riscv64/-/sharp-linux-riscv64-0.35.3.tgz",
+      "integrity": "sha512-0Eob78yjlYPfL5vMNWAW55l3R9Y6BQS/gOfe0ZcP9mEz9ohhKSt4im1hayiknXgf8AWrFqMvJcKIdmLmEe7yeQ==",
       "cpu": [
         "riscv64"
       ],
@@ -856,19 +875,19 @@
         "linux"
       ],
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linux-riscv64": "1.2.4"
+        "@img/sharp-libvips-linux-riscv64": "1.3.2"
       }
     },
     "node_modules/@img/sharp-linux-s390x": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-s390x/-/sharp-linux-s390x-0.34.5.tgz",
-      "integrity": "sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==",
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-s390x/-/sharp-linux-s390x-0.35.3.tgz",
+      "integrity": "sha512-KgAxQ0DxpNOq1rG2t5cgTgShJFGSuU7XO45cqC+1NVOuZnP6tlgZRuSYOfNupGkHID0o3cJOsw4DVeJpMovcGw==",
       "cpu": [
         "s390x"
       ],
@@ -878,19 +897,19 @@
         "linux"
       ],
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linux-s390x": "1.2.4"
+        "@img/sharp-libvips-linux-s390x": "1.3.2"
       }
     },
     "node_modules/@img/sharp-linux-x64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.34.5.tgz",
-      "integrity": "sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==",
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.35.3.tgz",
+      "integrity": "sha512-8pqvxubL2PGdhlPy6GLqzDYMUjyRmKAwKHYKixpdJYBUK7PJ0C029XdsnpFIdgRZG68fZiGdHVWcKPvtiPB4cA==",
       "cpu": [
         "x64"
       ],
@@ -900,19 +919,19 @@
         "linux"
       ],
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linux-x64": "1.2.4"
+        "@img/sharp-libvips-linux-x64": "1.3.2"
       }
     },
     "node_modules/@img/sharp-linuxmusl-arm64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.34.5.tgz",
-      "integrity": "sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==",
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.35.3.tgz",
+      "integrity": "sha512-Vz0iQjzzcSX3HCbfwFfCSG/9SCIqyO0mH2sXyiHaAYfBk0cRsCWXRyQYX0ovCK/PAQBbTzQ0dsPQHh5MAFL59w==",
       "cpu": [
         "arm64"
       ],
@@ -922,19 +941,19 @@
         "linux"
       ],
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linuxmusl-arm64": "1.2.4"
+        "@img/sharp-libvips-linuxmusl-arm64": "1.3.2"
       }
     },
     "node_modules/@img/sharp-linuxmusl-x64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.34.5.tgz",
-      "integrity": "sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==",
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.35.3.tgz",
+      "integrity": "sha512-6O1NPKcDVj9QEdg7Hx549EX8U0rp6yXQERqru6yRN7fGBn32UvIRJUlWnk+8xDCiG76hXVBbX82NZ/ZKr0euIg==",
       "cpu": [
         "x64"
       ],
@@ -944,38 +963,54 @@
         "linux"
       ],
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linuxmusl-x64": "1.2.4"
+        "@img/sharp-libvips-linuxmusl-x64": "1.3.2"
       }
     },
     "node_modules/@img/sharp-wasm32": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-wasm32/-/sharp-wasm32-0.34.5.tgz",
-      "integrity": "sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw==",
-      "cpu": [
-        "wasm32"
-      ],
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-wasm32/-/sharp-wasm32-0.35.3.tgz",
+      "integrity": "sha512-cZ0XkcYGpHZkqW6iCkqTcmUC0CD9DhD5d/qeZlZkfRBn6GnHniZXLUo5+9xw8Iv76YE6LQFN9YNBlKREcCG76w==",
       "license": "Apache-2.0 AND LGPL-3.0-or-later AND MIT",
       "optional": true,
       "dependencies": {
-        "@emnapi/runtime": "^1.7.0"
+        "@emnapi/runtime": "^1.11.1"
       },
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-webcontainers-wasm32": {
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-webcontainers-wasm32/-/sharp-webcontainers-wasm32-0.35.3.tgz",
+      "integrity": "sha512-2rnq7bX3NzeR2T4YWgz8qiG4h3TSdMe+vN1iQXpJleSJ3SM5zQ8Fy2SyyXAWlbxpEZ2Y+Z4u1BePgJEYbSy80Q==",
+      "cpu": [
+        "wasm32"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "@img/sharp-wasm32": "0.35.3"
+      },
+      "engines": {
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       }
     },
     "node_modules/@img/sharp-win32-arm64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-win32-arm64/-/sharp-win32-arm64-0.34.5.tgz",
-      "integrity": "sha512-WQ3AgWCWYSb2yt+IG8mnC6Jdk9Whs7O0gxphblsLvdhSpSTtmu69ZG1Gkb6NuvxsNACwiPV6cNSZNzt0KPsw7g==",
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-arm64/-/sharp-win32-arm64-0.35.3.tgz",
+      "integrity": "sha512-4bPwFdMbeC4JQ8L8LOyWp6nsHcboP5fxkp6iPOXz2Vg49R42TuMs2whkJ5OAP4/Ul035qOzy0AecOF9VOscn4w==",
       "cpu": [
         "arm64"
       ],
@@ -985,16 +1020,16 @@
         "win32"
       ],
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       }
     },
     "node_modules/@img/sharp-win32-ia32": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-win32-ia32/-/sharp-win32-ia32-0.34.5.tgz",
-      "integrity": "sha512-FV9m/7NmeCmSHDD5j4+4pNI8Cp3aW+JvLoXcTUo0IqyjSfAZJ8dIUmijx1qaJsIiU+Hosw6xM5KijAWRJCSgNg==",
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-ia32/-/sharp-win32-ia32-0.35.3.tgz",
+      "integrity": "sha512-r53mXsBN6lFUDiST764SvgwUdHAqM4rPAiDzAmf4fLoB6X/rkfyTrLCg6+g17wJJiCmB3JYgHuUldCWUIRFSXw==",
       "cpu": [
         "ia32"
       ],
@@ -1004,16 +1039,16 @@
         "win32"
       ],
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": "^20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       }
     },
     "node_modules/@img/sharp-win32-x64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-win32-x64/-/sharp-win32-x64-0.34.5.tgz",
-      "integrity": "sha512-+29YMsqY2/9eFEiW93eqWnuLcWcufowXewwSNIT6UwZdUUCrM3oFjMWH/Z6/TMmb4hlFenmfAVbpWeup2jryCw==",
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-x64/-/sharp-win32-x64-0.35.3.tgz",
+      "integrity": "sha512-D4y1vNeZrIIJCN+uHaWVtH86B+aCrdMYYjicy9pXHvbGZeGYLLSd3wdVuC37FxVXlU1ARsk84eKWfWMXGYEqvA==",
       "cpu": [
         "x64"
       ],
@@ -1023,7 +1058,7 @@
         "win32"
       ],
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
@@ -1087,9 +1122,9 @@
       }
     },
     "node_modules/@next/env": {
-      "version": "16.2.6",
-      "resolved": "https://registry.npmjs.org/@next/env/-/env-16.2.6.tgz",
-      "integrity": "sha512-gd8HoHN4ufj73WmR3JmVolrpJR47ILK6LouP5xElPglaVxir6e1a7VzvTvDWkOoPXT9rkkTzyCxBu4yeZfZwcw==",
+      "version": "16.2.12",
+      "resolved": "https://registry.npmjs.org/@next/env/-/env-16.2.12.tgz",
+      "integrity": "sha512-d0Z5Bc13Fa4nR8pFAKx2jay2yhJM16vlfHbTzYnUQAxlNb6B6lmn4hjt69lYNt4kRtyYP6gEM49lPRHNbIyneg==",
       "license": "MIT"
     },
     "node_modules/@next/eslint-plugin-next": {
@@ -1103,9 +1138,9 @@
       }
     },
     "node_modules/@next/swc-darwin-arm64": {
-      "version": "16.2.6",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-16.2.6.tgz",
-      "integrity": "sha512-ZJGkkcNfYgrrMkqOdZ7zoLa1TOy0qpcMfk/z4Mh/FKUz40gVO+HNQWqmLxf67Z5WB64DRp0dhEbyHfel+6sJUg==",
+      "version": "16.2.12",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-16.2.12.tgz",
+      "integrity": "sha512-0W1R0teHWJrqKX0FH20IzzIWAOuGtBxPGuObrxy1lE8hQvCFj49KE8a3WUg0D7sq6rn6zkM4c7YGUnhudBS6oA==",
       "cpu": [
         "arm64"
       ],
@@ -1119,9 +1154,9 @@
       }
     },
     "node_modules/@next/swc-darwin-x64": {
-      "version": "16.2.6",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-16.2.6.tgz",
-      "integrity": "sha512-v/YLBHIY132Ced3puBJ7YJKw1lqsCrgcNo2aRJlCEyQrrCeRJlvGlnmxhPxNQI3KE3N1DN5r9TPNPvka3nq5RQ==",
+      "version": "16.2.12",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-16.2.12.tgz",
+      "integrity": "sha512-Hy5Ls099+aFUmOLmIgPfLqNi6iCwhL3uQCssz5rWk+5Nkc6TUKCE83DY5BbNylfm3+mfwcSFnLRfrZDJhVxdtw==",
       "cpu": [
         "x64"
       ],
@@ -1135,14 +1170,11 @@
       }
     },
     "node_modules/@next/swc-linux-arm64-gnu": {
-      "version": "16.2.6",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-16.2.6.tgz",
-      "integrity": "sha512-RPOvqlYBbcQjkz9VQQDZ2T2bARIjXZV1KFlt+V2Mr6SW/e4I9fcKsaA0hdyf2FHoTlsV2xnBd5Y912rP/1Ce6w==",
+      "version": "16.2.12",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-16.2.12.tgz",
+      "integrity": "sha512-+YqU2h1cQkHsGfvjAsrSmst8UIFBibBGm5x3Xgel8NLMiDQtNOM4sM2GOEMvG5YiOBNeN/Ykk8cQC2S0Xrqljg==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "MIT",
       "optional": true,
@@ -1154,14 +1186,11 @@
       }
     },
     "node_modules/@next/swc-linux-arm64-musl": {
-      "version": "16.2.6",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-16.2.6.tgz",
-      "integrity": "sha512-URUTu1+dMkxJsPFgm+OeEvq9wf5sujw0EvgYy80TDGHTSLTnIHeqb0Eu8A3sC95IRgjejQL+kC4mw+4yPxiAXA==",
+      "version": "16.2.12",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-16.2.12.tgz",
+      "integrity": "sha512-0qjhiYBaKAqF63LA1ZWAAnKTzFUguAaZiRa5etMLGGPj/B6uEVjtIZldIzFEp3wHlB0koK6aTzqPtSdplTCjoA==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -1173,14 +1202,11 @@
       }
     },
     "node_modules/@next/swc-linux-x64-gnu": {
-      "version": "16.2.6",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-16.2.6.tgz",
-      "integrity": "sha512-DOj182mPV8G3UkrayLoREM5YEYI+Dk5wv7Ox9xl1fFibAELEsFD0lDPfHIeILlutMMfdyhlzYPELG3peuKaurw==",
+      "version": "16.2.12",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-16.2.12.tgz",
+      "integrity": "sha512-7A3q26W+h7gnA15uqBToNuDqBEFZZcqh0mW2mn4AJh/G5pdg2RVE3n4slzLEliASZFG3NmsbEzng/x2Sh09mBg==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "MIT",
       "optional": true,
@@ -1192,14 +1218,11 @@
       }
     },
     "node_modules/@next/swc-linux-x64-musl": {
-      "version": "16.2.6",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-16.2.6.tgz",
-      "integrity": "sha512-HKQ5SP/V/ub73UvF7n/zeJlxk2kLmtL7Wzrg4WfmkjmNos5onJ2tKu7yZOPdL18A6Svfn3max29ym+ry7NkK4g==",
+      "version": "16.2.12",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-16.2.12.tgz",
+      "integrity": "sha512-qSjL/uppm+cbh21s72Ss8gkiOhQ4dExWHNGOWy6eZV7STj5WsKehgxT61beSsOj+YYQuTplL376lOCdMQU5T8w==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -1211,9 +1234,9 @@
       }
     },
     "node_modules/@next/swc-win32-arm64-msvc": {
-      "version": "16.2.6",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-16.2.6.tgz",
-      "integrity": "sha512-LZXpTlPyS5v7HhSmnvsLGP3iIYgYOBnc8r8ArlT55sGHV89bR2HlDdBjWQ+PY6SJMmk8TuVGFuxalnP3k/0Dwg==",
+      "version": "16.2.12",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-16.2.12.tgz",
+      "integrity": "sha512-X6hzsOUJac/e7AWSbn9gQ9nzHld1xWP5iyjHpYWvud8pufB679O1xg4JDyKr8Xd69Jvd+kM2Der6uftiZCmjYA==",
       "cpu": [
         "arm64"
       ],
@@ -1227,9 +1250,9 @@
       }
     },
     "node_modules/@next/swc-win32-x64-msvc": {
-      "version": "16.2.6",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-16.2.6.tgz",
-      "integrity": "sha512-F0+4i0h9J6C4eE3EAPWsoCk7UW/dbzOjyzxY0qnDUOYFu6FFmdZ6l97/XdV3/Nz3VYyO7UWjyEJUXkGqcoXfMA==",
+      "version": "16.2.12",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-16.2.12.tgz",
+      "integrity": "sha512-F6fakeHuFTLOPt0bslQJdf+xtT+WIP9DVn/m4y1w1mRnVPyh3D/cNvzlRkxM444xfm+IvvYNSOrKiA2CDJ0Uxw==",
       "cpu": [
         "x64"
       ],
@@ -1312,9 +1335,9 @@
       }
     },
     "node_modules/@opentelemetry/core": {
-      "version": "2.7.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.7.1.tgz",
-      "integrity": "sha512-QAqIj32AtK6+pEVNG7EOVxHdE06RP+FM5qpiEJ4RtDcFIqKUZHYhl7/7UY5efhwmwNAg7j8QbJVBLxMerc0+gw==",
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.10.0.tgz",
+      "integrity": "sha512-/wNZ8twnEQQA4HoHu22+vcsdru6pWPWxW+7w+FlxT6Id7PE/WIbZmVKkte+PF72e0F2dnImFeHD2syyE1Mw6MQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@opentelemetry/semantic-conventions": "^1.29.0"
@@ -1344,12 +1367,29 @@
       }
     },
     "node_modules/@opentelemetry/resources": {
-      "version": "2.7.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.7.1.tgz",
-      "integrity": "sha512-DeT6KKolmC4e/dRQvMQ/RwlnzhaqeiFOXY5ngoOPJ07GgVVKxZOg9EcrNZb5aTzUn+iCrJldAgOfQm1O/QfPAQ==",
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.10.0.tgz",
+      "integrity": "sha512-q6MMm2zhggzsHVNbabYwut+a6nbuQQe3URUoxaojM/8K1IBfwwPzvxIjNi2/lI1TFe+fMHMW9MWhrtDLEXEnkA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/core": "2.7.1",
+        "@opentelemetry/core": "2.10.0",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.3.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-trace": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace/-/sdk-trace-2.10.0.tgz",
+      "integrity": "sha512-MfQGq3GRmTh5fM/y+OjaO0vj6+luCB1XO2gfXCalKCfgKw0eHL++sm75DNweC6ohlp+aFvACqeE0fYayqdRaoQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.10.0",
+        "@opentelemetry/resources": "2.10.0",
         "@opentelemetry/semantic-conventions": "^1.29.0"
       },
       "engines": {
@@ -1360,13 +1400,14 @@
       }
     },
     "node_modules/@opentelemetry/sdk-trace-base": {
-      "version": "2.7.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-2.7.1.tgz",
-      "integrity": "sha512-NAYIlsF8MPUsKqJMiDQJTMPOmlbawC1Iz/omMLygZ1C9am8fTKYjTaI+OZM+WTY3t3Glo0wnOg/6/pac6RGPPw==",
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-2.10.0.tgz",
+      "integrity": "sha512-GuYQQT7QD2EeO8lcZLRQzcbOyhqAzL+6WWTKTU9mSUBYBazkEDl+VrQcXQhbB08OWM9anD1aHleVadzulpOaUQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/core": "2.7.1",
-        "@opentelemetry/resources": "2.7.1",
+        "@opentelemetry/core": "2.10.0",
+        "@opentelemetry/resources": "2.10.0",
+        "@opentelemetry/sdk-trace": "2.10.0",
         "@opentelemetry/semantic-conventions": "^1.29.0"
       },
       "engines": {
@@ -1386,9 +1427,9 @@
       }
     },
     "node_modules/@oxc-project/types": {
-      "version": "0.127.0",
-      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.127.0.tgz",
-      "integrity": "sha512-aIYXQBo4lCbO4z0R3FHeucQHpF46l2LbMdxRvqvuRuW2OxdnSkcng5B8+K12spgLDj93rtN3+J2Vac/TIO+ciQ==",
+      "version": "0.142.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.142.0.tgz",
+      "integrity": "sha512-7W+2q5AKQVU36fkaryontrHn3YDt1RyUYXatw9i5H8ocYe2sPKSFB6eS8WNPeRKiN1qAWWZUPm7gwFzJGrccqQ==",
       "dev": true,
       "license": "MIT",
       "funding": {
@@ -1396,9 +1437,9 @@
       }
     },
     "node_modules/@rolldown/binding-android-arm64": {
-      "version": "1.0.0-rc.17",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.0-rc.17.tgz",
-      "integrity": "sha512-s70pVGhw4zqGeFnXWvAzJDlvxhlRollagdCCKRgOsgUOH3N1l0LIxf83AtGzmb5SiVM4Hjl5HyarMRfdfj3DaQ==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.2.1.tgz",
+      "integrity": "sha512-02hOeOSryYxVrOIphmLAsqnCJWxwlzFk+pEt/N/i6OgT3lShHO7xGCU5cpgchRDHboAEbSjzgGh+O/u1GswQmA==",
       "cpu": [
         "arm64"
       ],
@@ -1413,9 +1454,9 @@
       }
     },
     "node_modules/@rolldown/binding-darwin-arm64": {
-      "version": "1.0.0-rc.17",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.0-rc.17.tgz",
-      "integrity": "sha512-4ksWc9n0mhlZpZ9PMZgTGjeOPRu8MB1Z3Tz0Mo02eWfWCHMW1zN82Qz/pL/rC+yQa+8ZnutMF0JjJe7PjwasYw==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.2.1.tgz",
+      "integrity": "sha512-fMsTOnN0OjFm3CyppWPitKnc8UlliVARUULW6cfU6AIqjdtgmSFWSk9vecHzZduv/yMWIHDlRhM1e8Iff9uAfA==",
       "cpu": [
         "arm64"
       ],
@@ -1430,9 +1471,9 @@
       }
     },
     "node_modules/@rolldown/binding-darwin-x64": {
-      "version": "1.0.0-rc.17",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.0-rc.17.tgz",
-      "integrity": "sha512-SUSDOI6WwUVNcWxd02QEBjLdY1VPHvlEkw6T/8nYG322iYWCTxRb1vzk4E+mWWYehTp7ERibq54LSJGjmouOsw==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.2.1.tgz",
+      "integrity": "sha512-1wjKdz/XLGKHaTNHjQveQ/B23TKx4ItAqm1JbyVuvNPc4Ze0Fb48s49TAd/2zcplPl8okE/UbTgmlVfwT7eFeQ==",
       "cpu": [
         "x64"
       ],
@@ -1447,9 +1488,9 @@
       }
     },
     "node_modules/@rolldown/binding-freebsd-x64": {
-      "version": "1.0.0-rc.17",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.0-rc.17.tgz",
-      "integrity": "sha512-hwnz3nw9dbJ05EDO/PvcjaaewqqDy7Y1rn1UO81l8iIK1GjenME75dl16ajbvSSMfv66WXSRCYKIqfgq2KCfxw==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.2.1.tgz",
+      "integrity": "sha512-Fa0jHR07E7YBN4vOEsbVf2briYNsuOowfLJaXULZM0ldMlaCaj2LJgLMbMe4iacRyZmvR8efFhgR9wKuGclQUg==",
       "cpu": [
         "x64"
       ],
@@ -1464,9 +1505,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
-      "version": "1.0.0-rc.17",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.0-rc.17.tgz",
-      "integrity": "sha512-IS+W7epTcwANmFSQFrS1SivEXHtl1JtuQA9wlxrZTcNi6mx+FDOYrakGevvvTwgj2JvWiK8B29/qD9BELZPyXQ==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.2.1.tgz",
+      "integrity": "sha512-pzkgu1SSHGgRRyRZ4fbmSgmajbVt+epaLP99NDjFft69v/ypfTi6swBMiVdh2EkQ0OSnHE1lZDM7DRGkyAzUpA==",
       "cpu": [
         "arm"
       ],
@@ -1481,9 +1522,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-arm64-gnu": {
-      "version": "1.0.0-rc.17",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.0-rc.17.tgz",
-      "integrity": "sha512-e6usGaHKW5BMNZOymS1UcEYGowQMWcgZ71Z17Sl/h2+ZziNJ1a9n3Zvcz6LdRyIW5572wBCTH/Z+bKuZouGk9Q==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.2.1.tgz",
+      "integrity": "sha512-QI5SEDY8cbiYWHx0VO4vIc3UlS6a32vXHjU8Qy/17adEmZIPuByJg13UEvo9c/UCiUkdcVWY83C+b+JrwnNyUg==",
       "cpu": [
         "arm64"
       ],
@@ -1498,9 +1539,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-arm64-musl": {
-      "version": "1.0.0-rc.17",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.0-rc.17.tgz",
-      "integrity": "sha512-b/CgbwAJpmrRLp02RPfhbudf5tZnN9nsPWK82znefso832etkem8H7FSZwxrOI9djcdTP7U6YfNhbRnh7djErg==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.2.1.tgz",
+      "integrity": "sha512-Sm41FyCeXqmYcERoYOCbGIL5hNfd8w9LQ7Y61Bev48HkcjaJqV/iiVOaiDxjVTRMS+QKrZmD8cfPt4uMVnvM+A==",
       "cpu": [
         "arm64"
       ],
@@ -1515,9 +1556,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-ppc64-gnu": {
-      "version": "1.0.0-rc.17",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.0-rc.17.tgz",
-      "integrity": "sha512-4EII1iNGRUN5WwGbF/kOh/EIkoDN9HsupgLQoXfY+D1oyJm7/F4t5PYU5n8SWZgG0FEwakyM8pGgwcBYruGTlA==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.2.1.tgz",
+      "integrity": "sha512-2x+WhXTGl9yJYPbltW/BSEPTVz9OIWQyER4N+gJEDWkkn904eRcBzELqh/Hf7K0w/ubGbKNMv0ZC+94QK/IFEg==",
       "cpu": [
         "ppc64"
       ],
@@ -1532,9 +1573,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-s390x-gnu": {
-      "version": "1.0.0-rc.17",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.0-rc.17.tgz",
-      "integrity": "sha512-AH8oq3XqQo4IibpVXvPeLDI5pzkpYn0WiZAfT05kFzoJ6tQNzwRdDYQ45M8I/gslbodRZwW8uxLhbSBbkv96rA==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.2.1.tgz",
+      "integrity": "sha512-eEjmQpuRQayHPWWnywaWHkFT3ToPbP3RYy42VVd/B9aBGDA+Ol25EIWHxKQST3IiWJjikCWUF7KtbfqwZrzVwQ==",
       "cpu": [
         "s390x"
       ],
@@ -1549,9 +1590,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-x64-gnu": {
-      "version": "1.0.0-rc.17",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.0-rc.17.tgz",
-      "integrity": "sha512-cLnjV3xfo7KslbU41Z7z8BH/E1y5mzUYzAqih1d1MDaIGZRCMqTijqLv76/P7fyHuvUcfGsIpqCdddbxLLK9rA==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.2.1.tgz",
+      "integrity": "sha512-/Orga1fZYkLc/56jBICcHrKchl8Z2UKdDSr3LG9ToWO1lQ6a4Livk9Xz+9WN91zsz5QR3XQz2NNoSDEvP6qadw==",
       "cpu": [
         "x64"
       ],
@@ -1566,9 +1607,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-x64-musl": {
-      "version": "1.0.0-rc.17",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.0-rc.17.tgz",
-      "integrity": "sha512-0phclDw1spsL7dUB37sIARuis2tAgomCJXAHZlpt8PXZ4Ba0dRP1e+66lsRqrfhISeN9bEGNjQs+T/Fbd7oYGw==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.2.1.tgz",
+      "integrity": "sha512-xxBJRL+0q0Kce7orznGWLuylHDY65vuARXZRpX+hPdv+DqK2c3NlCsVA98tlWzWNEE7yPqA/1NQ5nnCrj49Y5A==",
       "cpu": [
         "x64"
       ],
@@ -1583,9 +1624,9 @@
       }
     },
     "node_modules/@rolldown/binding-openharmony-arm64": {
-      "version": "1.0.0-rc.17",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.0-rc.17.tgz",
-      "integrity": "sha512-0ag/hEgXOwgw4t8QyQvUCxvEg+V0KBcA6YuOx9g0r02MprutRF5dyljgm3EmR02O292UX7UeS6HzWHAl6KgyhA==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.2.1.tgz",
+      "integrity": "sha512-M6AdXIXw3s+/8XpKMzdGDEXGS1S7kwUsy+rcTIUIOx5Ge4nXKCtAFHFV9YKkXvGcC5WMoTjAteLzlsQROVI0Yw==",
       "cpu": [
         "arm64"
       ],
@@ -1600,47 +1641,81 @@
       }
     },
     "node_modules/@rolldown/binding-wasm32-wasi": {
-      "version": "1.0.0-rc.17",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.0-rc.17.tgz",
-      "integrity": "sha512-LEXei6vo0E5wTGwpkJ4KoT3OZJRnglwldt5ziLzOlc6qqb55z4tWNq2A+PFqCJuvWWdP53CVhG1Z9NtToDPJrA==",
-      "cpu": [
-        "wasm32"
-      ],
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.2.1.tgz",
+      "integrity": "sha512-/TX0SoRGojHzSAHpfVBbavRVSazg5U3h3Y3VXfcc0cdugq6kxdqw8LPGFiPr+/7gE/60zRcsOY2Vi9b9eT0jww==",
       "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
-        "@emnapi/core": "1.10.0",
-        "@emnapi/runtime": "1.10.0",
-        "@napi-rs/wasm-runtime": "^1.1.4"
+        "@emnapi/core": "2.0.0-alpha.3",
+        "@emnapi/runtime": "2.0.0-alpha.3",
+        "@napi-rs/wasm-runtime": "^1.2.0"
       },
       "engines": {
-        "node": "^20.19.0 || >=22.12.0"
+        "node": "^20.19.0 || ^22.13.0 || >=23.5.0"
+      }
+    },
+    "node_modules/@rolldown/binding-wasm32-wasi/node_modules/@emnapi/core": {
+      "version": "2.0.0-alpha.3",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-2.0.0-alpha.3.tgz",
+      "integrity": "sha512-AZypUeJ/yByuxyS7BlSNRDOMLMlROYtjYdIAuBmJssVz1UJDSeYxLrdizhXCFYhedC5bqd/ASy8EuNXbVVXp9g==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "2.0.1",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@rolldown/binding-wasm32-wasi/node_modules/@emnapi/runtime": {
+      "version": "2.0.0-alpha.3",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-2.0.0-alpha.3.tgz",
+      "integrity": "sha512-hFPAhMUjJD9BSyCANEISPOogeXC9Zo9ZQl7L6vKnaVsMkCtzznaW/naYypeyl0Gv5rYfWYsZbpixTMpjDJzQeA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@rolldown/binding-wasm32-wasi/node_modules/@emnapi/wasi-threads": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-2.0.1.tgz",
+      "integrity": "sha512-9DsSk+o5NBX0CCJT8s0EROGSGxjR/tKu6aBTaVyq+SjAEQH4XcdcRxPBRzsBLizTTJ49MJjF+jgu3qnO9GLQcQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
       }
     },
     "node_modules/@rolldown/binding-wasm32-wasi/node_modules/@napi-rs/wasm-runtime": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.4.tgz",
-      "integrity": "sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow==",
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.2.2.tgz",
+      "integrity": "sha512-JfB4kuJQjaoHuCTseIINHtHWeJnvgEcxjwA5t/Y00ZgaOO1Crz3fjT/p8kT28zA/Caz7oiUMn3d6H2yOVCVwuw==",
       "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
-        "@tybys/wasm-util": "^0.10.1"
+        "@tybys/wasm-util": "^0.10.3"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=23.5.0"
       },
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/Brooooooklyn"
       },
       "peerDependencies": {
-        "@emnapi/core": "^1.7.1",
-        "@emnapi/runtime": "^1.7.1"
+        "@emnapi/core": "^1.7.1 || ^2.0.0-alpha.3",
+        "@emnapi/runtime": "^1.7.1 || ^2.0.0-alpha.3"
       }
     },
     "node_modules/@rolldown/binding-win32-arm64-msvc": {
-      "version": "1.0.0-rc.17",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.0-rc.17.tgz",
-      "integrity": "sha512-gUmyzBl3SPMa6hrqFUth9sVfcLBlYsbMzBx5PlexMroZStgzGqlZ26pYG89rBb45Mnia+oil6YAIFeEWGWhoZA==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.2.1.tgz",
+      "integrity": "sha512-EvRrivJieyHG+AO9lleZWgq+g0+S7oV2C51yuqlcyU/R9net+sI4Pj0F+lUoP2bEr6TWX3SqFaaS0SzfLxSzkw==",
       "cpu": [
         "arm64"
       ],
@@ -1655,9 +1730,9 @@
       }
     },
     "node_modules/@rolldown/binding-win32-x64-msvc": {
-      "version": "1.0.0-rc.17",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.0-rc.17.tgz",
-      "integrity": "sha512-3hkiolcUAvPB9FLb3UZdfjVVNWherN1f/skkGWJP/fgSQhYUZpSIRr0/I8ZK9TkF3F7kxvJAk0+IcKvPHk9qQg==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.2.1.tgz",
+      "integrity": "sha512-Z4eCmn5QJ/5+azF9knpLWKfVd9aidn0mAe9TpJgvBLId9Ax3t0+JVxBmT25Bv7NBbVW1TZyKjQjQReouMeH5UQ==",
       "cpu": [
         "x64"
       ],
@@ -1823,9 +1898,6 @@
       "cpu": [
         "arm"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1838,9 +1910,6 @@
       "integrity": "sha512-J3Yh9PzzF1Ovah2At+lHiGQdsYgArxBbXv/zHfSyaiFQEqvNv7DcW98pCrmdjCZBrqBiKrKKe2V+aaSGWuBe/w==",
       "cpu": [
         "arm"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -1855,9 +1924,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1870,9 +1936,6 @@
       "integrity": "sha512-pc9EYOSlOgdQ2uPl1o9PF6/kLSgaUosia7gOuS8mB69IxJvlclko1MECXysjs5ryez1/5zjYqx3+xYU0TU6R1A==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -1887,9 +1950,6 @@
       "cpu": [
         "loong64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1902,9 +1962,6 @@
       "integrity": "sha512-nbJnQ8a3z1mtmrwImCYhc6BGpThAyYVRQxw9uKSKG4wR6aAYno9sVjJ0zaZcW9BPJX1GbrDPf+SvdWjgTuDmnw==",
       "cpu": [
         "loong64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -1919,9 +1976,6 @@
       "cpu": [
         "ppc64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1934,9 +1988,6 @@
       "integrity": "sha512-WeBtoMuaMxiiIrO2IYP3xs6GMWkJP2C0EoT8beTLkUPmzV1i/UcOSVw1d5r9KBODtHKilG5yFxsGRnBbK3wJ4A==",
       "cpu": [
         "ppc64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -1951,9 +2002,6 @@
       "cpu": [
         "riscv64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1966,9 +2014,6 @@
       "integrity": "sha512-mcEl6CUT5IAUmQf1m9FYSmVqCJlpQ8r8eyftFUHG8i9OhY7BkBXSUdnLH5DOf0wCOjcP9v/QO93zpmF1SptCCw==",
       "cpu": [
         "riscv64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -1983,9 +2028,6 @@
       "cpu": [
         "s390x"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1999,9 +2041,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2014,9 +2053,6 @@
       "integrity": "sha512-+qfSY27qIrFfI/Hom04KYFw3GKZSGU4lXus51wsb5EuySfFlWRwjkKWoE9emgRw/ukoT4Udsj4W/+xxG8VbPKg==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -2675,9 +2711,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2693,9 +2726,6 @@
       "integrity": "sha512-Z6sukiQsngnWO+l39X4pPbiWT81IC+PLKF+PHxIlyZbGNb9MODfYlXEVlFvej5BOZInWX01kVyzeLvHsXhfczQ==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -2713,9 +2743,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2731,9 +2758,6 @@
       "integrity": "sha512-Z0IADbDo8bh6I7h2IQMx601AdXBLfFpEdUotft86evd/8ZPflZe9COPO8Q1vw+pfLWIUo9zN/JGZvwuAJqduqg==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -2908,9 +2932,9 @@
       }
     },
     "node_modules/@tybys/wasm-util": {
-      "version": "0.10.1",
-      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.1.tgz",
-      "integrity": "sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==",
+      "version": "0.10.3",
+      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.3.tgz",
+      "integrity": "sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -3208,16 +3232,16 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion": {
-      "version": "5.0.6",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
-      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
       },
       "engines": {
-        "node": "18 || 20 || >=22"
+        "node": "20 || >=22"
       }
     },
     "node_modules/@typescript-eslint/typescript-estree/node_modules/minimatch": {
@@ -4147,9 +4171,9 @@
       "license": "MIT"
     },
     "node_modules/baseline-browser-mapping": {
-      "version": "2.10.21",
-      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.21.tgz",
-      "integrity": "sha512-Q+rUQ7Uz8AHM7DEaNdwvfFCTq7a43lNTzuS94eiWqwyxfV/wJv+oUivef51T91mmRY4d4A1u9rcSvkeufCVXlA==",
+      "version": "2.11.9",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.11.9.tgz",
+      "integrity": "sha512-cp447VUsGS07+n1Dqf7YSQ8maeJrjEhaDxTm1ZefbqDtypHBC5GzGMQbklR6IPR13Y8OAJRHZWEMtZipJLCttg==",
       "license": "Apache-2.0",
       "bin": {
         "baseline-browser-mapping": "dist/cli.cjs"
@@ -4159,9 +4183,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.14",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
-      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4183,9 +4207,9 @@
       }
     },
     "node_modules/browserslist": {
-      "version": "4.28.2",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.2.tgz",
-      "integrity": "sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg==",
+      "version": "4.28.7",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.7.tgz",
+      "integrity": "sha512-JxV13hNrFxqjOc8alRbq9dK1MM79NEXYpma2B2J4wAtpWS5zIEIKqWPGCl7N4o7Uc7B7itylh7SuDujATRyyTw==",
       "funding": [
         {
           "type": "opencollective",
@@ -4202,10 +4226,10 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "baseline-browser-mapping": "^2.10.12",
-        "caniuse-lite": "^1.0.30001782",
-        "electron-to-chromium": "^1.5.328",
-        "node-releases": "^2.0.36",
+        "baseline-browser-mapping": "^2.10.44",
+        "caniuse-lite": "^1.0.30001806",
+        "electron-to-chromium": "^1.5.393",
+        "node-releases": "^2.0.51",
         "update-browserslist-db": "^1.2.3"
       },
       "bin": {
@@ -4276,9 +4300,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001790",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001790.tgz",
-      "integrity": "sha512-bOoxfJPyYo+ds6W0YfptaCWbFnJYjh2Y1Eow5lRv+vI2u8ganPZqNm1JwNh0t2ELQCqIWg4B3dWEusgAmsoyOw==",
+      "version": "1.0.30001806",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001806.tgz",
+      "integrity": "sha512-72Cuvd95zbSYPKq6Fhg8eDJRlzgWDf7/mtoZv6Qe/DYNCEBdNxoA3+rZAU2ZhGCpZlns3EssFavaZomckT5Uuw==",
       "funding": [
         {
           "type": "opencollective",
@@ -4648,9 +4672,9 @@
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.344",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.344.tgz",
-      "integrity": "sha512-4MxfbmNDm+KPh066EZy+eUnkcDPcZ35wNmOWzFuh/ijvHsve6kbLTLURy88uCNK5FbpN+yk2nQY6BYh1GEt+wg==",
+      "version": "1.5.399",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.399.tgz",
+      "integrity": "sha512-lEcqhErbHjXRvd41rnWLpzbyU/IXfIYo7QwaFWmxGeLiLyY2TBCdHnWY88vB+p3ubnihRypDm66panXl7TylLA==",
       "license": "ISC"
     },
     "node_modules/emoji-regex": {
@@ -5791,15 +5815,15 @@
       }
     },
     "node_modules/glob/node_modules/brace-expansion": {
-      "version": "5.0.6",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
-      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
       },
       "engines": {
-        "node": "18 || 20 || >=22"
+        "node": "20 || >=22"
       }
     },
     "node_modules/glob/node_modules/minimatch": {
@@ -6634,10 +6658,20 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
-      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
+      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
       "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
       "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"
@@ -7365,9 +7399,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.11",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
-      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "version": "3.3.16",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
+      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
       "funding": [
         {
           "type": "github",
@@ -7406,12 +7440,12 @@
       "license": "MIT"
     },
     "node_modules/next": {
-      "version": "16.2.6",
-      "resolved": "https://registry.npmjs.org/next/-/next-16.2.6.tgz",
-      "integrity": "sha512-qOVgKJg1+At15NpeUP+eJgCHvTCgXsogweq87Ri/Ix7PkqQHg4sdaXmSFqKlgaIXE4kW0g25LE68W87UANlHtw==",
+      "version": "16.2.12",
+      "resolved": "https://registry.npmjs.org/next/-/next-16.2.12.tgz",
+      "integrity": "sha512-iD59eYQWmbFcEbX7v/acG5DRym9iw1DdaPoD0WTA920naWsE25wShzJW4+UvAs8MK9EC2kBfIH6vtto1H1PHGw==",
       "license": "MIT",
       "dependencies": {
-        "@next/env": "16.2.6",
+        "@next/env": "16.2.12",
         "@swc/helpers": "0.5.15",
         "baseline-browser-mapping": "^2.9.19",
         "caniuse-lite": "^1.0.30001579",
@@ -7425,14 +7459,14 @@
         "node": ">=20.9.0"
       },
       "optionalDependencies": {
-        "@next/swc-darwin-arm64": "16.2.6",
-        "@next/swc-darwin-x64": "16.2.6",
-        "@next/swc-linux-arm64-gnu": "16.2.6",
-        "@next/swc-linux-arm64-musl": "16.2.6",
-        "@next/swc-linux-x64-gnu": "16.2.6",
-        "@next/swc-linux-x64-musl": "16.2.6",
-        "@next/swc-win32-arm64-msvc": "16.2.6",
-        "@next/swc-win32-x64-msvc": "16.2.6",
+        "@next/swc-darwin-arm64": "16.2.12",
+        "@next/swc-darwin-x64": "16.2.12",
+        "@next/swc-linux-arm64-gnu": "16.2.12",
+        "@next/swc-linux-arm64-musl": "16.2.12",
+        "@next/swc-linux-x64-gnu": "16.2.12",
+        "@next/swc-linux-x64-musl": "16.2.12",
+        "@next/swc-win32-arm64-msvc": "16.2.12",
+        "@next/swc-win32-x64-msvc": "16.2.12",
         "sharp": "^0.34.5"
       },
       "peerDependencies": {
@@ -7498,10 +7532,13 @@
       }
     },
     "node_modules/node-releases": {
-      "version": "2.0.38",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.38.tgz",
-      "integrity": "sha512-3qT/88Y3FbH/Kx4szpQQ4HzUbVrHPKTLVpVocKiLfoYvw9XSGOX2FmD2d6DrXbVYyAQTF2HeF6My8jmzx7/CRw==",
-      "license": "MIT"
+      "version": "2.0.51",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.51.tgz",
+      "integrity": "sha512-wRNIrw4DmVLKQlbgOMdkMx27Wrpzes2hh5Jtbi2bjPd+4wJstWIqP5A+lscnqbm0xxmT5Bpg8Lec5ItEBwx6BQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/object-assign": {
       "version": "4.1.1",
@@ -7797,9 +7834,9 @@
       "license": "ISC"
     },
     "node_modules/picomatch": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
-      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
+      "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
       "license": "MIT",
       "engines": {
         "node": ">=12"
@@ -7825,9 +7862,9 @@
       "license": "MIT-0"
     },
     "node_modules/postcss": {
-      "version": "8.5.12",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.12.tgz",
-      "integrity": "sha512-W62t/Se6rA0Az3DfCL0AqJwXuKwBeYg6nOaIgzP+xZ7N5BFCI7DYi1qs6ygUYT6rvfi6t9k65UMLJC+PHZpDAA==",
+      "version": "8.5.25",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.25.tgz",
+      "integrity": "sha512-DTPx3RWSSnWyzLxQnlH0rJP+EW5ekl16ZU4/psbIhA0e53kJfdgaN5vKM+xP7yJtXVu+nfdVFmlgFDEKAe4Pyw==",
       "funding": [
         {
           "type": "opencollective",
@@ -7844,7 +7881,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.11",
+        "nanoid": "^3.3.16",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },
@@ -8250,14 +8287,14 @@
       "license": "MIT"
     },
     "node_modules/rolldown": {
-      "version": "1.0.0-rc.17",
-      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.0-rc.17.tgz",
-      "integrity": "sha512-ZrT53oAKrtA4+YtBWPQbtPOxIbVDbxT0orcYERKd63VJTF13zPcgXTvD4843L8pcsI7M6MErt8QtON6lrB9tyA==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.2.1.tgz",
+      "integrity": "sha512-4FKJhg8d3OiyQOA6Q1Q0hoFFpW9/OoX+VsHzpECsdsIZoOArrAK90gl59YK/Z+gnDel45bgJZK03ozH/9bCqEw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@oxc-project/types": "=0.127.0",
-        "@rolldown/pluginutils": "1.0.0-rc.17"
+        "@oxc-project/types": "=0.142.0",
+        "@rolldown/pluginutils": "^1.0.0"
       },
       "bin": {
         "rolldown": "bin/cli.mjs"
@@ -8266,29 +8303,22 @@
         "node": "^20.19.0 || >=22.12.0"
       },
       "optionalDependencies": {
-        "@rolldown/binding-android-arm64": "1.0.0-rc.17",
-        "@rolldown/binding-darwin-arm64": "1.0.0-rc.17",
-        "@rolldown/binding-darwin-x64": "1.0.0-rc.17",
-        "@rolldown/binding-freebsd-x64": "1.0.0-rc.17",
-        "@rolldown/binding-linux-arm-gnueabihf": "1.0.0-rc.17",
-        "@rolldown/binding-linux-arm64-gnu": "1.0.0-rc.17",
-        "@rolldown/binding-linux-arm64-musl": "1.0.0-rc.17",
-        "@rolldown/binding-linux-ppc64-gnu": "1.0.0-rc.17",
-        "@rolldown/binding-linux-s390x-gnu": "1.0.0-rc.17",
-        "@rolldown/binding-linux-x64-gnu": "1.0.0-rc.17",
-        "@rolldown/binding-linux-x64-musl": "1.0.0-rc.17",
-        "@rolldown/binding-openharmony-arm64": "1.0.0-rc.17",
-        "@rolldown/binding-wasm32-wasi": "1.0.0-rc.17",
-        "@rolldown/binding-win32-arm64-msvc": "1.0.0-rc.17",
-        "@rolldown/binding-win32-x64-msvc": "1.0.0-rc.17"
+        "@rolldown/binding-android-arm64": "1.2.1",
+        "@rolldown/binding-darwin-arm64": "1.2.1",
+        "@rolldown/binding-darwin-x64": "1.2.1",
+        "@rolldown/binding-freebsd-x64": "1.2.1",
+        "@rolldown/binding-linux-arm-gnueabihf": "1.2.1",
+        "@rolldown/binding-linux-arm64-gnu": "1.2.1",
+        "@rolldown/binding-linux-arm64-musl": "1.2.1",
+        "@rolldown/binding-linux-ppc64-gnu": "1.2.1",
+        "@rolldown/binding-linux-s390x-gnu": "1.2.1",
+        "@rolldown/binding-linux-x64-gnu": "1.2.1",
+        "@rolldown/binding-linux-x64-musl": "1.2.1",
+        "@rolldown/binding-openharmony-arm64": "1.2.1",
+        "@rolldown/binding-wasm32-wasi": "1.2.1",
+        "@rolldown/binding-win32-arm64-msvc": "1.2.1",
+        "@rolldown/binding-win32-x64-msvc": "1.2.1"
       }
-    },
-    "node_modules/rolldown/node_modules/@rolldown/pluginutils": {
-      "version": "1.0.0-rc.17",
-      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.17.tgz",
-      "integrity": "sha512-n8iosDOt6Ig1UhJ2AYqoIhHWh/isz0xpicHTzpKBeotdVsTEcxsSA/i3EVM7gQAj0rU27OLAxCjzlj15IWY7bg==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/rollup": {
       "version": "4.60.4",
@@ -8478,54 +8508,59 @@
       }
     },
     "node_modules/sharp": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.34.5.tgz",
-      "integrity": "sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg==",
-      "hasInstallScript": true,
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.35.3.tgz",
+      "integrity": "sha512-ej0zVHuZGHCiABXcNxeYhpRnPNPAcvbG8RMdBAhDAxLKkCRVSpK3Iyu7qbqw3JMzoj0REeM6f3tJLtVwl0023Q==",
       "license": "Apache-2.0",
       "optional": true,
       "dependencies": {
-        "@img/colour": "^1.0.0",
+        "@img/colour": "^1.1.0",
         "detect-libc": "^2.1.2",
-        "semver": "^7.7.3"
+        "semver": "^7.8.5"
       },
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-darwin-arm64": "0.34.5",
-        "@img/sharp-darwin-x64": "0.34.5",
-        "@img/sharp-libvips-darwin-arm64": "1.2.4",
-        "@img/sharp-libvips-darwin-x64": "1.2.4",
-        "@img/sharp-libvips-linux-arm": "1.2.4",
-        "@img/sharp-libvips-linux-arm64": "1.2.4",
-        "@img/sharp-libvips-linux-ppc64": "1.2.4",
-        "@img/sharp-libvips-linux-riscv64": "1.2.4",
-        "@img/sharp-libvips-linux-s390x": "1.2.4",
-        "@img/sharp-libvips-linux-x64": "1.2.4",
-        "@img/sharp-libvips-linuxmusl-arm64": "1.2.4",
-        "@img/sharp-libvips-linuxmusl-x64": "1.2.4",
-        "@img/sharp-linux-arm": "0.34.5",
-        "@img/sharp-linux-arm64": "0.34.5",
-        "@img/sharp-linux-ppc64": "0.34.5",
-        "@img/sharp-linux-riscv64": "0.34.5",
-        "@img/sharp-linux-s390x": "0.34.5",
-        "@img/sharp-linux-x64": "0.34.5",
-        "@img/sharp-linuxmusl-arm64": "0.34.5",
-        "@img/sharp-linuxmusl-x64": "0.34.5",
-        "@img/sharp-wasm32": "0.34.5",
-        "@img/sharp-win32-arm64": "0.34.5",
-        "@img/sharp-win32-ia32": "0.34.5",
-        "@img/sharp-win32-x64": "0.34.5"
+        "@img/sharp-darwin-arm64": "0.35.3",
+        "@img/sharp-darwin-x64": "0.35.3",
+        "@img/sharp-freebsd-wasm32": "0.35.3",
+        "@img/sharp-libvips-darwin-arm64": "1.3.2",
+        "@img/sharp-libvips-darwin-x64": "1.3.2",
+        "@img/sharp-libvips-linux-arm": "1.3.2",
+        "@img/sharp-libvips-linux-arm64": "1.3.2",
+        "@img/sharp-libvips-linux-ppc64": "1.3.2",
+        "@img/sharp-libvips-linux-riscv64": "1.3.2",
+        "@img/sharp-libvips-linux-s390x": "1.3.2",
+        "@img/sharp-libvips-linux-x64": "1.3.2",
+        "@img/sharp-libvips-linuxmusl-arm64": "1.3.2",
+        "@img/sharp-libvips-linuxmusl-x64": "1.3.2",
+        "@img/sharp-linux-arm": "0.35.3",
+        "@img/sharp-linux-arm64": "0.35.3",
+        "@img/sharp-linux-ppc64": "0.35.3",
+        "@img/sharp-linux-riscv64": "0.35.3",
+        "@img/sharp-linux-s390x": "0.35.3",
+        "@img/sharp-linux-x64": "0.35.3",
+        "@img/sharp-linuxmusl-arm64": "0.35.3",
+        "@img/sharp-linuxmusl-x64": "0.35.3",
+        "@img/sharp-webcontainers-wasm32": "0.35.3",
+        "@img/sharp-win32-arm64": "0.35.3",
+        "@img/sharp-win32-ia32": "0.35.3",
+        "@img/sharp-win32-x64": "0.35.3"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
       }
     },
     "node_modules/sharp/node_modules/semver": {
-      "version": "7.7.4",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
-      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
       "license": "ISC",
       "optional": true,
       "bin": {
@@ -9038,9 +9073,9 @@
       }
     },
     "node_modules/tinyglobby": {
-      "version": "0.2.16",
-      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.16.tgz",
-      "integrity": "sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==",
+      "version": "0.2.17",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
+      "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -9374,17 +9409,17 @@
       }
     },
     "node_modules/vite": {
-      "version": "8.0.10",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.10.tgz",
-      "integrity": "sha512-rZuUu9j6J5uotLDs+cAA4O5H4K1SfPliUlQwqa6YEwSrWDZzP4rhm00oJR5snMewjxF5V/K3D4kctsUTsIU9Mw==",
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-8.2.0.tgz",
+      "integrity": "sha512-pn+CFpM0lwDeKwmOq1ZaBK/9sjorZcgqxki6MbY/jPEVd9vichIlmlD4HmQ5wdP5EgqQCFRaACBxMC7uEGc6lQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "lightningcss": "^1.32.0",
-        "picomatch": "^4.0.4",
-        "postcss": "^8.5.10",
-        "rolldown": "1.0.0-rc.17",
-        "tinyglobby": "^0.2.16"
+        "lightningcss": "^1.33.0",
+        "picomatch": "^4.0.5",
+        "postcss": "^8.5.23",
+        "rolldown": "~1.2.0",
+        "tinyglobby": "^0.2.17"
       },
       "bin": {
         "vite": "bin/vite.js"
@@ -9400,7 +9435,7 @@
       },
       "peerDependencies": {
         "@types/node": "^20.19.0 || >=22.12.0",
-        "@vitejs/devtools": "^0.1.0",
+        "@vitejs/devtools": "^0.4.0",
         "esbuild": "^0.27.0 || ^0.28.0",
         "jiti": ">=1.21.0",
         "less": "^4.0.0",
@@ -9449,6 +9484,267 @@
         "yaml": {
           "optional": true
         }
+      }
+    },
+    "node_modules/vite/node_modules/lightningcss": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.33.0.tgz",
+      "integrity": "sha512-WkUDrojuJs0xkgGf2udWxa3yGBRxPtxUkB79i6aCZLRgc7PM8fZe9TosfPDcvEpQZbuFASnHYmRLBLUbmLOIIA==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "dependencies": {
+        "detect-libc": "^2.0.3"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      },
+      "optionalDependencies": {
+        "lightningcss-android-arm64": "1.33.0",
+        "lightningcss-darwin-arm64": "1.33.0",
+        "lightningcss-darwin-x64": "1.33.0",
+        "lightningcss-freebsd-x64": "1.33.0",
+        "lightningcss-linux-arm-gnueabihf": "1.33.0",
+        "lightningcss-linux-arm64-gnu": "1.33.0",
+        "lightningcss-linux-arm64-musl": "1.33.0",
+        "lightningcss-linux-x64-gnu": "1.33.0",
+        "lightningcss-linux-x64-musl": "1.33.0",
+        "lightningcss-win32-arm64-msvc": "1.33.0",
+        "lightningcss-win32-x64-msvc": "1.33.0"
+      }
+    },
+    "node_modules/vite/node_modules/lightningcss-android-arm64": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.33.0.tgz",
+      "integrity": "sha512-gEpRTalKdosp4Bb8qWtc2iOgE5SeIHlpS1up9bFq2wAyYhl1UdTObYiHe98zEM9SQvSoqQZ1IQD0JNpg3Ml5pg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/vite/node_modules/lightningcss-darwin-arm64": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.33.0.tgz",
+      "integrity": "sha512-Sciaz8eenNTKn9b3t7+xr0ipTp9YxKQY4npwQ3mrRuL0BAVHBLyZxofhaKBAVtzmtRZ/zTyo0/to4B1uWG/Djg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/vite/node_modules/lightningcss-darwin-x64": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.33.0.tgz",
+      "integrity": "sha512-Z5UPAxzrjlWNNyGy6i65cJzzvgJ5D3T6wMvs+gWpY9d7qRhANrxqAp6LhxIgZhWEw18RfJTGcRxjuLIBr+m8XQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/vite/node_modules/lightningcss-freebsd-x64": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.33.0.tgz",
+      "integrity": "sha512-QQM/Ti/hQajJwCY+RiWuCZ9sdtI/XQk7nDK5vC8kkdwixezOlDgvDx7+RT+QjK6FcFT4MpsuoBnHIo/O3StRRg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/vite/node_modules/lightningcss-linux-arm-gnueabihf": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.33.0.tgz",
+      "integrity": "sha512-N7FVBe6iS24MlM6R/4RBTxGhQheZGs7tiQ9U32UtF75NzP5Q7xWPRqLBCKxlRQRk3rY1jCIPLzx7WzOhuUIRLQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/vite/node_modules/lightningcss-linux-arm64-gnu": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.33.0.tgz",
+      "integrity": "sha512-j2v/itmy4HlNxlc6voKXYgBqNi0Ng2LShg4z7GufpEgs05P+2suBVyi9I6YHq5uoVFx9ETin3eCEhLVyXGQnKg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/vite/node_modules/lightningcss-linux-arm64-musl": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.33.0.tgz",
+      "integrity": "sha512-yiO5ROMuYQgXbC60yjZU5CYSFZGKXL0HFATXt9mHJn1+zW55oCtMI9NfcVhYLMFDL7gV7oBPon/EmMMGg2OvtQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/vite/node_modules/lightningcss-linux-x64-gnu": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.33.0.tgz",
+      "integrity": "sha512-ar+Ju7LmcN0Jo4FpL4hpFybwNG9/3A/Br5KW2n2jyODg3MEZXaDYADdemoNS+BDNfMgKvylJLj4S5tyRActuAg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/vite/node_modules/lightningcss-linux-x64-musl": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.33.0.tgz",
+      "integrity": "sha512-RYiYbkokw0trfKqqzfF55lginwEPrD3OJDfTuJzFs1MK6iFnDenaz1fqLLtX4ITG3OktJQXOeTaw1awrBAlZPw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/vite/node_modules/lightningcss-win32-arm64-msvc": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.33.0.tgz",
+      "integrity": "sha512-1K+MPfLSFVpphzpdbfkhlWk6wBrTObBzS2T6db10PNOZgR9GoVsAWzwNyuhUYYbTp23j+4RrncfujZ4uAzXvwA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/vite/node_modules/lightningcss-win32-x64-msvc": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.33.0.tgz",
+      "integrity": "sha512-OlEICDx/Xl0FqSp4bry8zFnCvGpig3Gl4gCquvYwHuqJKEC1+n9NgDniFvqHGmMv1ZkqDJrDqKKSykTDX+ehuA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
       }
     },
     "node_modules/vitest": {

--- a/package.json
+++ b/package.json
@@ -64,7 +64,8 @@
   },
   "overrides": {
     "uuid": "^14.0.0",
-    "postcss": "^8.5.10"
+    "postcss": "^8.5.18",
+    "sharp": "^0.35.0"
   },
   "lint-staged": {
     "*.{ts,tsx}": [


### PR DESCRIPTION
Security audit of the public attack surface, plus the fixes required to get CI green.

## What was audited

The site is a static Next.js 16 portfolio. The only route accepting untrusted input is `POST /api/contact`, so that's where the real surface is. Also reviewed: the `proxy.ts` locale middleware, the JSON-LD injection sink, security headers/CSP, error boundaries, the Upstash rate limiter, and the service-worker kill switch.

Much of the app was already well hardened (origin gate, CR/LF header stripping, PII-free Sentry capture, fail-closed `RESEND_FROM_EMAIL`, strong CSP + HSTS). Three real issues remained.

## Findings fixed

**1. CSRF origin bypass — the significant one.** `app/api/contact/route.ts`

The allowlist accepted any host satisfying `endsWith('.vercel.app') && includes('zachlamb')`. Vercel project names are globally claimable, so **anyone** could deploy a project named `zachlamb-evil`, get `zachlamb-evil.vercel.app`, and pass the check. That let an attacker-controlled page drive the contact form cross-origin and send mail into the owner's inbox with an attacker-chosen `reply-to` — a phishing primitive, not just spam.

Now matched exactly against the server-only env vars Vercel injects (`VERCEL_PROJECT_PRODUCTION_URL` / `VERCEL_BRANCH_URL` / `VERCEL_URL`). Preview deploys keep working; no wildcard remains to abuse.

**2. Plaintext `localhost` origins trusted in production.** Now gated to non-production only.

**3. No type validation on the JSON body.** Fields were *typed* `string | undefined` but never *checked*, so a non-string `name` reached `.trim()` and threw a `TypeError` that escaped the handler as an opaque 500. The body is now parsed as `unknown` with each field type-checked before use (parse, don't validate), values trimmed once, and length caps applied to the trimmed string so whitespace padding can't smuggle an oversized payload.

**Defense in depth:** the JSON-LD payload now goes through `lib/json-ld.ts`, which escapes `<` so a value containing a closing `script` tag can't break out of the `dangerouslySetInnerHTML` sink. Inputs are static today — this makes the sink safe by construction rather than by assumption.

## CI was already red on main

Independent of the security work, three CI gates were failing at the base commit:

- `npm run format:check` — 17 pre-existing unformatted files
- `npm audit --audit-level=high` — 6 high-severity advisories
- (both in the Quality job)

Fixed in separate commits so the security diff stays reviewable. Dependency patches: `next 16.2.6→16.2.12`, `vite 8.0.10→8.2.0`, `postcss 8.5.12→8.5.25`, `js-yaml 4.1.1→4.3.1`. `sharp` needed an override rather than `audit fix --force`, which wanted to downgrade Next to 14.2.35; it's an optional dep of Next and the libvips CVEs are fixed in 0.35.x.

## Verification

- **288 tests pass** (273 before, +15 new)
- Both origin regressions were **verified against the old code** — they fail before the fix and pass after, so they're pinning real behavior
- `npm audit --audit-level=high` → 0 vulnerabilities
- lint, format:check, typecheck, and `next build` all pass locally

## Note

GitHub reports 79 Dependabot alerts on the default branch. This PR clears everything `npm audit --audit-level=high` sees in the resolved tree; the rest appear to be alerts against the lockfile history / lower severities and are worth a separate pass.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)