### PR TITLE
copy: rewrite site copy to cut repetition and AI-tell phrasing

### DIFF
--- a/components/sections/About.test.tsx
+++ b/components/sections/About.test.tsx
@@ -37,7 +37,7 @@ describe('About', () => {
   it('renders pull-quote and personal note', () => {
     renderWithLocale(<About />);
     expect(screen.getByText(/I'm a Technical Product Manager/)).toBeInTheDocument();
-    expect(screen.getByText(/Oreo debate/)).toBeInTheDocument();
+    expect(screen.getByText(/strong opinions about Oreos/)).toBeInTheDocument();
   });
 
   it('does not use aria-label on non-interactive paragraph elements', () => {

--- a/components/sections/Services.test.tsx
+++ b/components/sections/Services.test.tsx
@@ -11,9 +11,9 @@ import { renderWithLocale } from '@/lib/test-utils';
 import { Services } from './Services';
 
 describe('Services', () => {
-  it('renders "What I Bring" heading', () => {
+  it('renders "How I Work" heading', () => {
     renderWithLocale(<Services />);
-    expect(screen.getByText('What I Bring')).toBeInTheDocument();
+    expect(screen.getByText('How I Work')).toBeInTheDocument();
   });
 
   it('renders all 4 service titles', () => {

--- a/data/services.ts
+++ b/data/services.ts
@@ -11,27 +11,27 @@ export const services: ServiceEntry[] = [
     title: 'Technical Product Strategy',
     icon: 'compass',
     description:
-      "I own the roadmap from discovery to delivery, balancing technical constraints with business outcomes. I've consolidated 400+ backlog items into structured projects and built dual roadmaps spanning multiple teams.",
+      'I own the roadmap from discovery through delivery. At Circadence that meant turning 409 loose backlog items into ten projects a team could actually plan against.',
   },
   {
     id: 'ai-augmented-engineering',
     title: 'AI-Augmented Engineering',
     icon: 'sparkles',
     description:
-      'I embed AI tooling into team workflows — Claude Code in grooming, MCP for roadmap surfacing, shared agent configs — so quality scales without bottlenecking on review.',
+      'I put AI tooling where the team already works: Claude Code in grooming sessions, MCP for surfacing roadmap context, shared agent configs so nobody starts from scratch.',
   },
   {
     id: 'process-delivery',
     title: 'Process & Delivery',
     icon: 'users',
     description:
-      "Certified ScrumMaster who builds the sprint cadence, retros, and cross-functional rhythms that let teams ship reliably. I've designed hiring processes adopted company-wide.",
+      "Certified ScrumMaster. I set up the sprint cadence and retros that make delivery predictable, and I've built hiring processes that got adopted company-wide.",
   },
   {
     id: 'engineering-product-bridge',
     title: 'Engineering ↔ Product Bridge',
     icon: 'code',
     description:
-      'I go deep on React, TypeScript, and system architecture when the work calls for it, so product decisions stay technically grounded.',
+      "When the work calls for it I'm still in React and TypeScript myself, which keeps product decisions honest about what the build actually costs.",
   },
 ];

--- a/data/site.ts
+++ b/data/site.ts
@@ -16,7 +16,7 @@ export const siteConfig = {
   name: 'Zach Lamb',
   title: 'Technical Product Manager',
   description:
-    'Technical Product Manager who owns the roadmap, runs the team, and goes deep on the technical decisions that matter. React, TypeScript, and AI-powered product development. Certified ScrumMaster with a Human Centered Computing background.',
+    'Technical Product Manager and former senior engineer. I own the roadmap and still read the pull requests. React, TypeScript, and AI-assisted delivery.',
   url: 'https://zachlamb.io',
   ogImage: '/og.png',
   availability: 'Open to remote',

--- a/messages/en.json
+++ b/messages/en.json
@@ -5,7 +5,7 @@
   "site": {
     "name": "Zach Lamb",
     "title": "Technical Product Manager",
-    "description": "Technical Product Manager who owns the roadmap, runs the team, and goes deep on the technical decisions that matter. React, TypeScript, and AI-powered product development. Certified ScrumMaster with a Human Centered Computing background."
+    "description": "Technical Product Manager and former senior engineer. I own the roadmap and still read the pull requests. React, TypeScript, and AI-assisted delivery."
   },
   "nav": {
     "trailGuide": "Trail Guide",
@@ -25,9 +25,9 @@
     "title": "Zach Lamb",
     "subtitle": "Technical Product Manager",
     "taglines": [
-      "Technical product lead with an engineering background. I own the roadmap, run the team, and keep both from drifting apart.",
-      "React, TypeScript, and LLM apps — I know what to build and how to ship it.",
-      "Always up for a conversation about code, AI, the outdoors, or Oreos."
+      "I spent ten years as an engineer before I owned a roadmap. It shows in how I run one.",
+      "React, TypeScript, and LLM apps. I can scope the work and I can build it.",
+      "Happy to talk shop, trade trail recommendations, or argue about Oreos."
     ],
     "getInTouch": "Get in Touch",
     "learnMore": "Learn More",
@@ -37,15 +37,27 @@
   "about": {
     "heading": "Trail Guide",
     "body": [
-      "I'm a Technical Product Manager with a frontend engineering background, which means I own the roadmap, run the team, and can still go deep on the technical decisions that actually matter."
+      "I'm a Technical Product Manager who came up through frontend engineering. That background is the whole point: I can sit in a roadmap review and a code review on the same afternoon and be useful in both."
     ],
     "stats": [
-      { "value": "10+", "label": "Years Building" },
-      { "value": "5", "label": "Industries" },
-      { "value": "CSM", "label": "Certified" },
-      { "value": "IC↔PM", "label": "Dual Track" }
+      {
+        "value": "10+",
+        "label": "Years Building"
+      },
+      {
+        "value": "5",
+        "label": "Industries"
+      },
+      {
+        "value": "CSM",
+        "label": "Certified"
+      },
+      {
+        "value": "IC↔PM",
+        "label": "Dual Track"
+      }
     ],
-    "personalNote": "When I'm not at my desk, I'm teaching yoga, hiking Colorado's trails, or trying to settle the Oreo debate once and for all.",
+    "personalNote": "Outside work I teach yoga and hike as much of Colorado as I can get to. I also have strong opinions about Oreos.",
     "focusAreas": "Technical Product Management · Roadmap Ownership · React & TypeScript · AI/LLM Integration · Cross-functional Leadership · Certified ScrumMaster"
   },
   "footer": {
@@ -57,7 +69,7 @@
   },
   "contact": {
     "heading": "Leave a Note at Camp",
-    "intro": "Whether it's about code, the trail ahead, or Oreos — drop a note and I'll get back to you from base camp. I typically reply within a day.",
+    "intro": "Drop a note and I'll usually get back to you within a day. There's no wrong reason to reach out.",
     "name": "Name",
     "email": "Email",
     "message": "Message",
@@ -78,11 +90,11 @@
     "projects": "Selected Work",
     "endorsements": "Recommendations",
     "skills": "Gear",
-    "services": "What I Bring",
+    "services": "How I Work",
     "education": "Credentials"
   },
   "projects": {
-    "intro": "A handful of projects that show how I think about users, shipping, and where AI earns its keep."
+    "intro": "A few projects worth showing, with notes on what I was solving and what I'd change."
   },
   "endorsements": {
     "intro": "What fellow hikers have said about working with me.",
@@ -103,7 +115,7 @@
     "certifications": "Certifications"
   },
   "skills": {
-    "intro": "The tools and practices I reach for — trail-tested and production-ready."
+    "intro": "The tools I've actually shipped with, not the ones I've read about."
   },
   "privacy": {
     "pageTitle": "Privacy Policy",


### PR DESCRIPTION
Copy audit of the English site copy, in three passes as requested. **Stacked on #91** — based on the security branch so CI is green; the diff reduces to copy-only once #91 merges. Retarget to `main` after that.

## Pass 1 — mistakes and structure

**The same sentence appeared three times.** "…owns the roadmap, runs the team, and goes deep on the technical decisions that matter" was in the meta description, the hero tagline, *and* the About body, near-verbatim. Scrolling the page you read the same claim three times in a row. Each now makes a distinct point: the hero states the background, About shows what it looks like in practice, the meta description carries the search snippet.

**Meta description was 236 chars.** Google truncates around 155. Now 150.

**"What I Bring"** was the one generic, non-thematic section name sitting among Trail Guide / Trail Log / Gear / Lodge / Credentials. Now "How I Work".

**Service copy led with abstractions.** "Balancing technical constraints with business outcomes" says nothing a competing candidate couldn't also write. Replaced with the specific: "turning 409 loose backlog items into ten projects a team could actually plan against."

## Pass 2 — sounding human

Shorter sentences, concrete images, plain verbs. The clearest example is About — it used to *assert* the trait ("can still go deep on the technical decisions that actually matter"); it now *describes the behavior*: "I can sit in a roadmap review and a code review on the same afternoon and be useful in both."

Skills went from "The tools and practices I reach for — trail-tested and production-ready" to "The tools I've actually shipped with, not the ones I've read about."

## Pass 3 — AI slop removal

- **Cut phrases:** "that actually matter", "earns its keep", "reach for", "trail-tested and production-ready", "Whether it's X, Y, or Z".
- **Broke the tricolon habit.** Nearly every sentence was a three-item list — this was the strongest AI tell in the original. Kept exactly one, in the hero, where it reads as personality. Also caught "trail recommendations" appearing in two adjacent sections after the first rewrite.
- **Removed em-dashes from marketing copy.** Kept the three in the privacy policy, where they're ordinary parentheticals in legal prose rather than a stylistic tic.
- **Scanned everything** against a slop list (delve, leverage, robust, seamless, elevate, unlock, harness, empower, showcase, holistic, synergy, streamline, foster, facilitate, curated, meticulous, crucial, pivotal, "not just", "when it comes to", …): **0 hits remaining.**

## Verification

288 tests, lint, typecheck, format:check, `npm audit`, and `next build` all pass. Two tests asserted on the old strings and were updated.

## Two things for you to decide

1. **`you@zachlamb.io` is a placeholder that ships in production.** It's hardcoded in `app/[locale]/privacy/page.tsx:12` and `components/sections/Contact.tsx:22`, and the privacy policy tells EU/UK visitors to email it to exercise their GDPR access/deletion rights. Nobody reading it can actually reach you. I didn't guess a replacement — picking your public-facing address is your call.
2. **The other five locales still carry the old copy.** Key parity holds (the parity test passes) so nothing is broken, but es/de/it/ja/zh now read from the previous English. Happy to propagate the rewrite if you want them in sync.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)